### PR TITLE
Atualizar documentação do Codex - Monitoramento e Preprocessamento

### DIFF
--- a/docs/source/deploying.rst
+++ b/docs/source/deploying.rst
@@ -191,3 +191,51 @@ The first method you need to call is :py:meth:`neomaril_codex.pipeline.NeomarilP
 
 Next, you can manually run the monitoring process, calling the method :py:meth:`neomaril_codex.pipeline.NeomarilPipeline.run_monitoring`.
 
+
+Using with preprocess script
+----------------------------
+
+Sometimes you want to run a preprocess script to adjust the model input data before executing it. With Neomaril you can do it.
+
+You must first instantiate the :py:class:`neomaril_codex.base.NeomarilExecution`:
+
+.. code:: python
+
+    model_client = NeomarilModelClient()
+    # >>> 2023-10-26 10:26:42.351 | INFO     | neomaril_codex.model:__init__:722 - Loading .env
+    # >>> 2023-10-26 10:26:42.352 | INFO     | neomaril_codex.base:__init__:90 - Loading .env
+    # >>> 2023-10-26 10:26:43.716 | INFO     | neomaril_codex.base:__init__:102 - Successfully connected to Neomaril
+
+And now you just need to run the model using the preprocess script, as created on **TBD preprocessing**.
+For the **sync model**:
+
+.. code:: python
+
+    sync_model = model_client.get_model(group='datarisk', model_id='M3aa182ff161478a97f4d3b2dc0e9b064d5a9e7330174daeb302e01586b9654c')
+
+    sync_model.predict(data=sync_model.schema, preprocessing=sync_preprocessing)
+    # >>> 2023-10-26 10:26:45.121 | INFO     | neomaril_codex.model:get_model:820 - Model M3aa182ff161478a97f4d3b2dc0e9b064d5a9e7330174daeb302e01586b9654c its deployed. Fetching model.
+    # >>> 2023-10-26 10:26:45.123 | INFO     | neomaril_codex.model:__init__:69 - Loading .env
+    # >>> {'pred': 0, 'proba': 0.005841062869876623}
+
+And for the **async model**:
+
+.. code:: python
+
+    async_model = model_client.get_model(group='datarisk', model_id='Maa3449c7f474567b6556614a12039d8bfdad0117fec47b2a4e03fcca90b7e7c')
+
+    PATH = './samples/asyncModel/'
+
+    execution = async_model.predict(PATH+'input.csv', preprocessing=async_preprocessing)
+    execution.wait_ready()
+    # >>> 2023-10-26 10:26:51.460 | INFO     | neomaril_codex.model:get_model:820 - Model Maa3449c7f474567b6556614a12039d8bfdad0117fec47b2a4e03fcca90b7e7c its deployed. Fetching model.
+    # >>> 2023-10-26 10:26:51.461 | INFO     | neomaril_codex.model:__init__:69 - Loading .env
+    # >>> 2023-10-26 10:26:54.532 | INFO     | neomaril_codex.preprocessing:set_token:123 - Token for group datarisk added.
+    # >>> 2023-10-26 10:26:55.955 | INFO     | neomaril_codex.preprocessing:run:177 - Execution '4' started to generate 'Db84e3baffc3457b9729f39f9f37aa1cd8aada89d3434ea0925e539cb23d7d65'. Use the id to check its status.
+    # >>> 2023-10-26 10:26:55.956 | INFO     | neomaril_codex.base:__init__:279 - Loading .env
+    # >>> 2023-10-26 10:30:12.982 | INFO     | neomaril_codex.base:download_result:413 - Output saved in ./result_preprocessing
+    # >>> 2023-10-26 10:30:14.619 | INFO     | neomaril_codex.model:predict:365 - Execution '5' started. Use the id to check its status.
+    # >>> 2023-10-26 10:30:14.620 | INFO     | neomaril_codex.base:__init__:279 - Loading .env
+
+    execution.download_result()
+    # >>> 2023-10-26 10:32:28.296 | INFO     | neomaril_codex.base:download_result:413 - Output saved in ./output.zip

--- a/docs/source/deploying.rst
+++ b/docs/source/deploying.rst
@@ -176,14 +176,14 @@ You can call the :py:attr:`neomaril_codex.model.NeomarilModel.docs` attribute to
 Monitoring your model
 ---------------------
 
-Model monitoring means keeping track with how the model is being used in production so we can update the model if it start making bad predictions.
+Model monitoring means keeping track of how the model is being used in production, so you can update it if it starts making bad predictions.
 
-For now Neomaril only does indirect monitoring, that means following the input of the model in production and checking if is close to the data presented to the model in training.
-So when configure the monitoring we need to know which training generated that model and what features are relevant to monitoring the model.
+For now, Neomaril only does indirect monitoring. This means that Neomaril follows the input of the model in production and checks if it is close to the data presented to the model in training.
+So, when configuring the monitoring system, we need to know which training generated that model and what features are relevant to monitoring the model.
 
-Besides we need to know how to handle the features and the model. 
+Besides that, we need to know how to correctly handle the features and the model. 
 
-The production data is saved raw, and the training data is not (check :ref:`training_guide:Running a training execution`). So we need to know the steps in processing the raw data to get the model features like the ones we saved during training:
+The production data is saved raw, and the training data is not (check :ref:`training_guide:Running a training execution`). So we need to know the steps in processing the raw production data to get the model features like the ones we saved during training:
 
 **TBD in the preprocess module.**
 

--- a/docs/source/deploying.rst
+++ b/docs/source/deploying.rst
@@ -206,7 +206,7 @@ You must first instantiate the :py:class:`neomaril_codex.base.NeomarilExecution`
     # >>> 2023-10-26 10:26:42.352 | INFO     | neomaril_codex.base:__init__:90 - Loading .env
     # >>> 2023-10-26 10:26:43.716 | INFO     | neomaril_codex.base:__init__:102 - Successfully connected to Neomaril
 
-And now you just need to run the model using the preprocess script, as created on **TBD preprocessing**.
+And now you just need to run the model using the preprocess script (check :ref:`preprocessing:Preprocessing module`).
 For the **sync model**:
 
 .. code:: python

--- a/docs/source/deploying.rst
+++ b/docs/source/deploying.rst
@@ -48,7 +48,7 @@ The return of the function should be a dictionary that can be parsed to a JSON, 
 
 Keep in mind that some data types (like numpy `int64` and `float64` values) cannot normally be parsed to JSON, so your code should handle that before returning the response to Neomaril. 
 
-**Async model:** This is for batch scoring. We send files with usually a lot o records at once. Since this might take a while depeding on the file size, we run this asynchronously.
+**Async model:** This is for batch scoring. We send files with usually a lot of records at once. Since this might take a while depeding on the file size, we run this asynchronously.
 The entrypoint function should look like this:
 
 .. code:: python

--- a/docs/source/deploying.rst
+++ b/docs/source/deploying.rst
@@ -1,7 +1,7 @@
 Deploying to production
 =======================
 
-When deploying a model to Neomaril we create a API so you can connect your model with other services. You can also use Neomaril Codex to execute your model remotely inside a python application.
+When deploying a model to Neomaril we create an API so you can connect your model with other services. You can also use Neomaril Codex to execute your model remotely inside a python application.
 
 
 Preparing to production

--- a/docs/source/deploying.rst
+++ b/docs/source/deploying.rst
@@ -181,9 +181,13 @@ Model monitoring means keeping track of how the model is being used in productio
 For now, Neomaril only does indirect monitoring. This means that Neomaril follows the input of the model in production and checks if it is close to the data presented to the model in training.
 So, when configuring the monitoring system, we need to know which training generated that model and what features are relevant to monitoring the model.
 
+We offer both "Population Stability Index" (PSI and PSI average) and "SHapley Additive exPlanations" (SHAP and SHAP average) metrics.
+
 Besides that, we need to know how to correctly handle the features and the model. 
 
-The production data is saved raw, and the training data is not (check :ref:`training_guide:Running a training execution`). So we need to know the steps in processing the raw production data to get the model features like the ones we saved during training:
+The production data is saved raw, and the training data is not (check :ref:`training_guide:Running a training execution`). So we need to know the steps in processing the raw production data to get the model features like the ones we saved during training: :ref:`monitoring_parameters:Monitoring configuration`
 
-**TBD in the preprocess module.**
+The first method you need to call is :py:meth:`neomaril_codex.pipeline.NeomarilPipeline.register_monitoring_config`, which is responsible for registering the monitoring configuration at the database.
+
+Next, you can manually run the monitoring process, calling the method :py:meth:`neomaril_codex.pipeline.NeomarilPipeline.run_monitoring`.
 

--- a/docs/source/locale/pt_BR/LC_MESSAGES/base.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/base.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomaril-codex \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-05 15:49-0300\n"
+"POT-Creation-Date: 2023-12-04 12:08-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: pt\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.12.1\n"
+"Generated-By: Babel 2.13.1\n"
 
 #: ../../source/base.rst:2
 msgid "Base module"
@@ -32,11 +32,307 @@ msgstr "Módulo com as classes base usadas no Neomaril."
 msgid "neomaril\\_codex.base.BaseNeomaril"
 msgstr "neomaril\\_codex.base.BaseNeomaril"
 
+#: neomaril_codex.base.BaseNeomaril:1 of
+msgid "Bases: :py:class:`object`"
+msgstr "Bases: :py:class:`object`"
+
+#: neomaril_codex.base.BaseNeomaril:1 of
+msgid ""
+"Super base class to initialize other variables and URLs for other "
+"Neomaril classes."
+msgstr ""
+"Super classe base para inicializar outras variáveis e URLS para outras "
+"classes do Neomaril."
+
 #: ../../source/base.rst:18
 msgid "neomaril\\_codex.base.BaseNeomarilClient"
 msgstr "neomaril\\_codex.base.BaseNeomarilClient"
 
+#: neomaril_codex.base.BaseNeomarilClient:1
+#: neomaril_codex.base.NeomarilExecution:1 of
+#, fuzzy
+msgid "Bases: :py:class:`~neomaril_codex.base.BaseNeomaril`"
+msgstr "Bases: :py:class:`~neomaril_codex.base.BaseNeomaril`"
+
+#: neomaril_codex.base.BaseNeomarilClient:1 of
+msgid ""
+"Base class for Neomaril client side related classes. This is the class "
+"that contains some methods related to Client models administration. "
+"Mainly related to initialize environment and its variables, but also to "
+"generate groups. A group is a way to organize models clustering for "
+"different users and also to increase security. Each group has a unique "
+"token that should be used to run the models that belongs to that."
+msgstr ""
+"Classe base para o lado do cliente Neomaril. Esta é a classe "
+"que contém métodos relacionados à adiministração dos modelos do cliente. "
+"Principalmente relacionado à inicialização do ambiente e suas variáveis, mas também "
+"a geração de grupos. Um grupo é uma maneira de organizar os modelos agrupando para "
+"diferentes usuários e atambém para aumentar a segurança. Cada grupo tem um token "
+"único que deve ser usado para executar os modelos que pertencem a este grupo."
+
+#: neomaril_codex.base.BaseNeomarilClient:8
+#: neomaril_codex.base.NeomarilExecution:29 of
+msgid ""
+"Login for authenticating with the client. You can also use the env "
+"variable NEOMARIL_USER to set this"
+msgstr ""
+"Use o login para autenticar com o cliente. Você também pode usar a variável "
+"de ambiente NEOMARIL_USER para configurar isto"
+
+#: neomaril_codex.base.BaseNeomarilClient neomaril_codex.base.NeomarilExecution
+#: of
+msgid "type"
+msgstr "type"
+
+#: neomaril_codex.base.BaseNeomarilClient:10
+#: neomaril_codex.base.BaseNeomarilClient:16
+#: neomaril_codex.base.BaseNeomarilClient:22
+#: neomaril_codex.base.NeomarilExecution:7
+#: neomaril_codex.base.NeomarilExecution:13
+#: neomaril_codex.base.NeomarilExecution:31
+#: neomaril_codex.base.NeomarilExecution:37
+#: neomaril_codex.base.NeomarilExecution:43 of
+msgid "str"
+msgstr "str"
+
+#: neomaril_codex.base.BaseNeomarilClient:14
+#: neomaril_codex.base.NeomarilExecution:35 of
+msgid ""
+"Password for authenticating with the client. You can also use the env "
+"variable NEOMARIL_PASSWORD to set this"
+msgstr ""
+"Senha para autenticar com o cliente. Você também pode usar a variável "
+"de ambiente NEOMARIL_PASSWORD para configurar isto"
+
+#: neomaril_codex.base.BaseNeomarilClient:20
+#: neomaril_codex.base.NeomarilExecution:41 of
+msgid ""
+"URL to Neomaril Server. Default value is "
+"https://neomaril.staging.datarisk.net, use it to test your deployment "
+"first before changing to production. You can also use the env variable "
+"NEOMARIL_URL to set this"
+msgstr ""
+"URL para o servidor do Neomaril. O valor padrão é "
+"https://neomaril.staging.datarisk.net, use ele para testar seu deployment "
+"antes de mover para produção. Você também pode usar a variável de ambiente "
+"NEOMARIL_URL para configurar isto"
+
+#: neomaril_codex.base.BaseNeomarilClient
+#: neomaril_codex.base.BaseNeomarilClient.create_group
+#: neomaril_codex.base.BaseNeomarilClient.list_groups
+#: neomaril_codex.base.BaseNeomarilClient.refresh_group_token
+#: neomaril_codex.base.NeomarilExecution
+#: neomaril_codex.base.NeomarilExecution.download_result
+#: neomaril_codex.base.NeomarilExecution.get_status of
+msgid "Raises"
+msgstr "Raises"
+
+#: neomaril_codex.base.BaseNeomarilClient:24 of
+msgid "When the environment is production, becase itis not implemented yet"
+msgstr "Quando o ambiente é produção, pois não está implementado ainda"
+
+#: neomaril_codex.base.BaseNeomarilClient:27
+#: neomaril_codex.base.BaseNeomarilClient.refresh_group_token:16
+#: neomaril_codex.base.NeomarilExecution:49
+#: neomaril_codex.base.NeomarilExecution.wait_ready:4 of
+msgid "Example"
+msgstr "Example"
+
+#: neomaril_codex.base.BaseNeomarilClient:28 of
+msgid ""
+"In this example you can see how to create a group and after consult the "
+"list of groups that already exists."
+msgstr ""
+"Neste exemplo podemos ver como criar um grupo e depois consultar a "
+"lista de grupos que já existem."
+
+#: neomaril_codex.base.BaseNeomarilClient.create_group:1 of
+msgid ""
+"Create a group for multiple models of the same final client at the end if"
+" it returns TRUE, a message with the token for that group will be "
+"returned as a INFO message. You should keep this token information to be "
+"able to run the model of that group afterwards."
+msgstr ""
+"Create a group for multiple models of the same final client at the end if"
+" it returns TRUE, a message with the token for that group will be "
+"returned as a INFO message. You should keep this token information to be "
+"able to run the model of that group afterwards."
+
+#: neomaril_codex.base.BaseNeomarilClient.create_group
+#: neomaril_codex.base.BaseNeomarilClient.refresh_group_token
+#: neomaril_codex.base.NeomarilExecution.download_result of
+msgid "Parameters"
+msgstr "Parameters"
+
+#: neomaril_codex.base.BaseNeomarilClient.create_group:4 of
+msgid ""
+"Name of the group. Must be 32 characters long and with no special "
+"characters (some parsing will be made)"
+msgstr ""
+"Nome do grupo. Deve ter no máximo 32 caracteres e não pode conter caracteres "
+"especiais (algumas verificações serão feitas para validar isto)"
+
+#: neomaril_codex.base.BaseNeomarilClient.create_group:6 of
+msgid "Short description of the group"
+msgstr "Breve descrição do grupo"
+
+#: neomaril_codex.base.BaseNeomarilClient.create_group:9
+#: neomaril_codex.base.BaseNeomarilClient.list_groups:3
+#: neomaril_codex.base.BaseNeomarilClient.refresh_group_token:10 of
+msgid "Unexpected server error"
+msgstr "Unexpected server error"
+
+#: neomaril_codex.base.BaseNeomarilClient.create_group
+#: neomaril_codex.base.BaseNeomarilClient.list_groups
+#: neomaril_codex.base.BaseNeomarilClient.refresh_group_token
+#: neomaril_codex.base.NeomarilExecution.download_result
+#: neomaril_codex.base.NeomarilExecution.get_status of
+msgid "Returns"
+msgstr "Returns"
+
+#: neomaril_codex.base.BaseNeomarilClient.create_group:11 of
+msgid "Returns True if the group was successfully created and False if not"
+msgstr "Returns True if the group was successfully created and False if not"
+
+#: neomaril_codex.base.BaseNeomarilClient.create_group
+#: neomaril_codex.base.BaseNeomarilClient.list_groups
+#: neomaril_codex.base.BaseNeomarilClient.refresh_group_token
+#: neomaril_codex.base.NeomarilExecution.download_result
+#: neomaril_codex.base.NeomarilExecution.get_status of
+msgid "Return type"
+msgstr "Return type"
+
+#: neomaril_codex.base.BaseNeomarilClient.list_groups:1 of
+msgid "List all existing groups."
+msgstr "List all existing groups."
+
+#: neomaril_codex.base.BaseNeomarilClient.list_groups:5 of
+msgid "List with the groups that exists in the database"
+msgstr "List with the groups that exists in the database"
+
+#: neomaril_codex.base.BaseNeomarilClient.refresh_group_token:1 of
+msgid ""
+"Refresh the group token. If the the token its still valid it wont be "
+"changed, unless you use parameter force = True. At the end a message with"
+" the token for that group will be returned as a INFO message. You should "
+"keep this new token information to be able to run the model of that group"
+" afterwards."
+msgstr ""
+"Atualize o token do grupo. Se o token ainda for válido ele não será "
+"mudado, a menos que o parâmetro force = True seja usado. No fim uma mensagem com"
+" o token para o grupo será retornada em uma mensagem de INFO. Você deve "
+"guardar este novo token para ser capaz de executar o modelo daquele grupo"
+" futuramente."
+
+#: neomaril_codex.base.BaseNeomarilClient.refresh_group_token:5 of
+msgid "Name of the group to have the token refreshed"
+msgstr "Nome do grupo que deve ter seu token atualizado"
+
+#: neomaril_codex.base.BaseNeomarilClient.refresh_group_token:7 of
+msgid ""
+"Force token expiration even if its still valid (this can make multiple "
+"models integrations stop working, so use with care)"
+msgstr ""
+"Força a expiração do token mesmo que ele ainda seja válido (isto pode fazer com que múltiplas "
+"integrações entre modelos parem de funcionar, então use com cuidado)"
+
+#: neomaril_codex.base.BaseNeomarilClient.refresh_group_token:12 of
+msgid "Returns True if the group was successfully created and False if not."
+msgstr "Returns True if the group was successfully created and False if not."
+
+#: neomaril_codex.base.BaseNeomarilClient.refresh_group_token:17 of
+msgid ""
+"Supose that you lost the token to access your group, you can create a new"
+" one forcing it with this method as at the example below."
+msgstr ""
+"Suponha que você perdeu o token de acesso ao seu grupo, você pode criar um novo"
+" forçando com este método como mostrado no exemplo abaixo."
+
 #: ../../source/base.rst:27
 msgid "neomaril\\_codex.base.NeomarilExecution"
 msgstr "neomaril\\_codex.base.NeomarilExecution"
+
+#: neomaril_codex.base.NeomarilExecution:1 of
+msgid ""
+"Base class for Neomaril asynchronous model executions. With this class "
+"you can visualize the status of an execution and download the results "
+"after and execution has finished."
+msgstr ""
+"Classe base para a execução de modelos assíncronos no Neomaril. Com esta classe "
+"você pode visualizar o status de uma execução e baixar os resultados "
+"depois que a execução foi finalizada."
+
+#: neomaril_codex.base.NeomarilExecution:5 of
+msgid "Model id (hash) from the model you want to access"
+msgstr "Model id (hash) from the model you want to access"
+
+#: neomaril_codex.base.NeomarilExecution:11 of
+msgid ""
+"Flag that contains which type of execution you use. It can be "
+"'AsyncModel' or 'Training'"
+msgstr ""
+"Flag que contém qual o tipo de execução você usa. Ele pode ser "
+"'AsyncModel' ou 'Training'"
+
+#: neomaril_codex.base.NeomarilExecution:17 of
+msgid "Group the model is inserted"
+msgstr "Group the model is inserted"
+
+#: neomaril_codex.base.NeomarilExecution:19
+#: neomaril_codex.base.NeomarilExecution:25 of
+msgid "str, optional"
+msgstr "str, optional"
+
+#: neomaril_codex.base.NeomarilExecution:23 of
+msgid "Execution id"
+msgstr "Execution id"
+
+#: neomaril_codex.base.NeomarilExecution:45 of
+msgid "Invalid execution type"
+msgstr "Invalid execution type"
+
+#: neomaril_codex.base.NeomarilExecution:46 of
+msgid "If the exection id was not found or wasn't possible to retrive it"
+msgstr "If the exection id was not found or wasn't possible to retrive it"
+
+#: neomaril_codex.base.NeomarilExecution:50 of
+msgid ""
+"In this example you can see how to get the status of an existing "
+"execution and download its results"
+msgstr ""
+"Neste exemplo você pode ver como capturar o status de uma execução "
+"existente e baixar seus resultados"
+
+#: neomaril_codex.base.NeomarilExecution.download_result:1 of
+msgid "Gets the output of the execution."
+msgstr "Recebe a saída da execução."
+
+#: neomaril_codex.base.NeomarilExecution.download_result:3 of
+msgid "Path of the result file. Default value is './'"
+msgstr "Caminho para o arquivo de resultado. O valor padrão é './'"
+
+#: neomaril_codex.base.NeomarilExecution.download_result:5 of
+msgid "Name of the result file. Default value is 'output.zip'"
+msgstr "Nome do arquivo de resultado. O valor padrão é 'output.zip'"
+
+#: neomaril_codex.base.NeomarilExecution.download_result:8
+#: neomaril_codex.base.NeomarilExecution.get_status:3 of
+msgid "Execution unavailable"
+msgstr "Execution unavailable"
+
+#: neomaril_codex.base.NeomarilExecution.download_result:10 of
+msgid "Returns the path for the result file."
+msgstr "Retorna o caminho para o arquivo de resultados."
+
+#: neomaril_codex.base.NeomarilExecution.get_status:1 of
+msgid "Gets the status of the related execution."
+msgstr "Recebe o status da execução relacionada."
+
+#: neomaril_codex.base.NeomarilExecution.get_status:5 of
+msgid "Returns the execution status."
+msgstr "Retorna o status da execução."
+
+#: neomaril_codex.base.NeomarilExecution.wait_ready:1 of
+msgid "Waits the execution until is no longer running"
+msgstr "Espera a execução até que ela pare de executar"
 

--- a/docs/source/locale/pt_BR/LC_MESSAGES/deploying.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/deploying.po
@@ -26,7 +26,7 @@ msgstr "Implantação (deploying) em produção"
 
 #: ../../source/deploying.rst:4
 msgid ""
-"When deploying a model to Neomaril we create a API so you can connect "
+"When deploying a model to Neomaril we create an API so you can connect "
 "your model with other services. You can also use Neomaril Codex to "
 "execute your model remotely inside a python application."
 msgstr ""

--- a/docs/source/locale/pt_BR/LC_MESSAGES/deploying.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/deploying.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomaril-codex \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-05 15:49-0300\n"
+"POT-Creation-Date: 2023-12-04 12:08-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: pt\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.12.1\n"
+"Generated-By: Babel 2.13.1\n"
 
 #: ../../source/deploying.rst:2
 msgid "Deploying to production"
@@ -30,9 +30,10 @@ msgid ""
 "your model with other services. You can also use Neomaril Codex to "
 "execute your model remotely inside a python application."
 msgstr ""
-"Quando implantamos um modelo no Neomaril, nós criamos uma API para que você consiga conectar "
-"seu modelo a outros serviços. Você pode também usar o Neomaril Codex para "
-"executar o modelo remotamente dentro de uma aplicação Python."
+"Quando implantamos um modelo no Neomaril, nós criamos uma API para que "
+"você consiga conectar seu modelo a outros serviços. Você pode também usar"
+" o Neomaril Codex para executar o modelo remotamente dentro de uma "
+"aplicação Python."
 
 #: ../../source/deploying.rst:8
 msgid "Preparing to production"
@@ -44,9 +45,9 @@ msgid ""
 " need a entrypoint function. The parameters and return of this function "
 "will depend on the model operation."
 msgstr ""
-"A primeira coisa que precisamos é do script de escoragem. Assim como no treinamento, nós"
-" precisamos de uma função de entrada (entrypoint). Os parâmetros e retornos dessa função "
-"vão depender da operação do modelo."
+"A primeira coisa que precisamos é do script de escoragem. Assim como no "
+"treinamento, nós precisamos de uma função de entrada (entrypoint). Os "
+"parâmetros e retornos dessa função vão depender da operação do modelo."
 
 #: ../../source/deploying.rst:13
 msgid ""
@@ -54,11 +55,12 @@ msgid ""
 "JSON and return a JSON after a few seconds. The entrypoint function "
 "should look like this:"
 msgstr ""
-"**Sync model:** Abreviação para modelo síncrono. Esse é o modelo que mais se aproxima da ideia de operação em \"tempo real\". Este modelo espera um "
-"JSON e retorna também um JSON após alguns segundos. A função de entrada (entrypoint) "
-"deve ser parecida com:"
+"**Sync model:** Abreviação para modelo síncrono. Esse é o modelo que mais"
+" se aproxima da ideia de operação em \"tempo real\". Este modelo espera "
+"um JSON e retorna também um JSON após alguns segundos. A função de "
+"entrada (entrypoint) deve ser parecida com:"
 
-#: ../../source/deploying.rst:25
+#: ../../source/deploying.rst:45
 msgid ""
 "The first parameter is the JSON data that will be sent to the model (this"
 " comes as a JSON string, so you should parse it the way you want). The "
@@ -67,36 +69,40 @@ msgid ""
 "the function should be a dictionary that can be parsed to a JSON, or a "
 "already valid JSON string."
 msgstr ""
-"O primeiro parâmetro é a entrada do modelo no formato JSON. Essa"
-" entrada é recebida como uma string JSON, então você pode decodificar (parse) da maneira que quiser. O "
-"outro parâmetro é um caminho (string). Assim como no treinamento, ele é usado para localizar tanto os arquivos do modelo,"
-" quanto outros arquivos que você pode subir (upload) para o Neomaril (veja a próxima seção). O retorno dessa "
-"função deve ser um dicionário que pode ser convertido em JSON, ou então uma "
-"string JSON válida."
+"O primeiro parâmetro é a entrada do modelo no formato JSON. Essa entrada "
+"é recebida como uma string JSON, então você pode decodificar (parse) da "
+"maneira que quiser. O outro parâmetro é um caminho (string). Assim como "
+"no treinamento, ele é usado para localizar tanto os arquivos do modelo, "
+"quanto outros arquivos que você pode subir (upload) para o Neomaril (veja"
+" a próxima seção). O retorno dessa função deve ser um dicionário que pode"
+" ser convertido em JSON, ou então uma string JSON válida."
 
-#: ../../source/deploying.rst:29
+#: ../../source/deploying.rst:49
 msgid ""
 "Keep in mind that some data types (like numpy `int64` and `float64` "
 "values) cannot normally be parsed to JSON, so your code should handle "
 "that before returning the response to Neomaril."
 msgstr ""
-"Tenha em mente que alguns tipos de dados (por exemplo valores numpy `int64` e `float64`) "
-"não podem ser convertidos em JSON normalmente, então seu código deve gerenciar "
-"esse passo antes de retornar a resposta para o Neomaril."
+"Tenha em mente que alguns tipos de dados (por exemplo valores numpy "
+"`int64` e `float64`) não podem ser convertidos em JSON normalmente, então"
+" seu código deve gerenciar esse passo antes de retornar a resposta para o"
+" Neomaril."
 
-#: ../../source/deploying.rst:31
+#: ../../source/deploying.rst:51
 msgid ""
 "**Async model:** This is for batch scoring. We send files with usually a "
-"lot of records at once. Since this might take a while depeding on the file"
-" size, we run this asynchronously. The entrypoint function should look "
-"like this:"
+"lot of records at once. Since this might take a while depeding on the "
+"file size, we run this asynchronously. The entrypoint function should "
+"look like this:"
 msgstr ""
-"**Async model:** Abreviação para modelo assíncrono. Esse tipo de modelo deve ser usado para cenários de escoragem em batch, onde são enviados arquivos com "
-"vários registros de uma vez. Como esse processo geralmente leva mais tempo para finalizar dependendo do tamanho dos arquivos de"
-" entrada, ele é executado de maneira assíncrona. A função de entrada (entrypoint) deve ser "
-"parecida com:"
+"**Async model:** Abreviação para modelo assíncrono. Esse tipo de modelo "
+"deve ser usado para cenários de escoragem em batch, onde são enviados "
+"arquivos com vários registros de uma vez. Como esse processo geralmente "
+"leva mais tempo para finalizar dependendo do tamanho dos arquivos de "
+"entrada, ele é executado de maneira assíncrona. A função de entrada "
+"(entrypoint) deve ser parecida com:"
 
-#: ../../source/deploying.rst:52
+#: ../../source/deploying.rst:95
 msgid ""
 "The first parameter is now also a path for the data. We have different "
 "path parameter because each async model execution is saved in a different"
@@ -107,24 +113,29 @@ msgid ""
 "You must save the result in the same path you got the input file. And the"
 " return of that function should be this full path."
 msgstr ""
-"O primeiro parâmetro dessa função é uma string com o caminho para encontrar os dados de entrada. Note que temos parâmetros diferentes "
-"para os caminhos da função, pois cada execução do modelo assíncrono é salva num local"
-" distinto. Além disso os arquivos enviados para o servidor (uploaded) quando implantando (deploying) o modelo são"
-" constantes. Se você deseja manter seu código mais dinâmico (e não "
-"forçar um padrão para o nome dos arquivos), você pode usar a variável de ambiente `inputFileName`, "
-"que terá o mesmo valor do nome do arquivo enviado (uploaded) para aquela execução. "
-"Você deve salvar o resultado no mesmo caminho usado para os arquivos de entrada. E o"
-" retorno dessa função deve ser o caminho completo do resultado."
+"O primeiro parâmetro dessa função é uma string com o caminho para "
+"encontrar os dados de entrada. Note que temos parâmetros diferentes para "
+"os caminhos da função, pois cada execução do modelo assíncrono é salva "
+"num local distinto. Além disso os arquivos enviados para o servidor "
+"(uploaded) quando implantando (deploying) o modelo são constantes. Se "
+"você deseja manter seu código mais dinâmico (e não forçar um padrão para "
+"o nome dos arquivos), você pode usar a variável de ambiente "
+"`inputFileName`, que terá o mesmo valor do nome do arquivo enviado "
+"(uploaded) para aquela execução. Você deve salvar o resultado no mesmo "
+"caminho usado para os arquivos de entrada. E o retorno dessa função deve "
+"ser o caminho completo do resultado."
 
-#: ../../source/deploying.rst:58
+#: ../../source/deploying.rst:101
 msgid "Deploying your model"
 msgstr "Implantando (deploying) seu modelo"
 
-#: ../../source/deploying.rst:60
+#: ../../source/deploying.rst:103
 msgid "With all files ready we can deploy the model in two ways."
-msgstr "Com todos os arquivos prontos podemos fazer a implantação do modelo de duas formas."
+msgstr ""
+"Com todos os arquivos prontos podemos fazer a implantação do modelo de "
+"duas formas."
 
-#: ../../source/deploying.rst:62
+#: ../../source/deploying.rst:105
 msgid ""
 "Using the "
 ":py:meth:`neomaril_codex.training.NeomarilTrainingExecution.promote_model`"
@@ -134,25 +145,25 @@ msgstr ""
 ":py:meth:`neomaril_codex.training.NeomarilTrainingExecution.promote_model`"
 " para promover uma execução de treinamento bem-sucedida."
 
-#: ../../source/deploying.rst:83
+#: ../../source/deploying.rst:126
 msgid ""
 "Using the "
 ":py:meth:`neomaril_codex.model.NeomarilModelClient.create_model` to "
 "deploy a model trained outside Neomaril"
 msgstr ""
-"Usando o "
-":py:meth:`neomaril_codex.model.NeomarilModelClient.create_model` para "
-"implantar o modelo treinado fora do Neomaril."
+"Usando o :py:meth:`neomaril_codex.model.NeomarilModelClient.create_model`"
+" para implantar o modelo treinado fora do Neomaril."
 
-#: ../../source/deploying.rst:103
+#: ../../source/deploying.rst:146
 msgid ""
 "As you can see deploying a model already trained in Neomaril requires "
 "less information (the AutoML models require only 2 parameters)."
 msgstr ""
 "Como você pode ver, implantar um modelo já treinado no Neomaril requer "
-"menos informações (os modelos vindo do AutoML requerem apenas 2 parâmetros)."
+"menos informações (os modelos vindo do AutoML requerem apenas 2 "
+"parâmetros)."
 
-#: ../../source/deploying.rst:105
+#: ../../source/deploying.rst:148
 msgid ""
 "Those methods return a :py:class:`neomaril_codex.model.NeomarilModel`. "
 "You can use the *wait_for_ready* parameter on the deployment method or "
@@ -163,44 +174,46 @@ msgid ""
 " tests. For the sync models we require a sample JSON of the expected "
 "schema for the API."
 msgstr ""
-"Esses métodos retornam uma :py:class:`neomaril_codex.model.NeomarilModel`. "
-"Você pode usar o parâmetro *wait_for_ready* no método de implantação, ou "
-"chamar o método :py:meth:`neomaril_codex.model.NeomarilModel.wait_ready` para garantir"
-" que a instância :py:class:`neomaril_codex.model.NeomarilModel` está "
-"pronta para uso. Nós vamos instalar as dependências do modelo (se você estiver promovendo"
-" um treinamento nós vamos usar as mesmas dependências usadas na execução do treinamento), e executar alguns"
-" testes. Para os modelos síncronos, é necessário um exemplo em JSON do esquema "
-"esperado para a API."
+"Esses métodos retornam uma "
+":py:class:`neomaril_codex.model.NeomarilModel`. Você pode usar o "
+"parâmetro *wait_for_ready* no método de implantação, ou chamar o método "
+":py:meth:`neomaril_codex.model.NeomarilModel.wait_ready` para garantir "
+"que a instância :py:class:`neomaril_codex.model.NeomarilModel` está "
+"pronta para uso. Nós vamos instalar as dependências do modelo (se você "
+"estiver promovendo um treinamento nós vamos usar as mesmas dependências "
+"usadas na execução do treinamento), e executar alguns testes. Para os "
+"modelos síncronos, é necessário um exemplo em JSON do esquema esperado "
+"para a API."
 
-#: ../../source/deploying.rst:108
+#: ../../source/deploying.rst:151
 msgid "If the deployment succeeds you can start using your model."
 msgstr "Se a implantação for bem-sucedida você pode já começar a usar seu modelo."
 
-#: ../../source/deploying.rst:111
+#: ../../source/deploying.rst:154
 msgid "Using your model"
 msgstr "Usando seu modelo"
 
-#: ../../source/deploying.rst:113
+#: ../../source/deploying.rst:156
 msgid ""
 "We can use the same :py:class:`neomaril_codex.model.NeomarilModel` "
 "instance to call the model."
 msgstr ""
-"Nós podemos usar a mesma instância :py:class:`neomaril_codex.model.NeomarilModel` "
-"para chamar o modelo."
+"Nós podemos usar a mesma instância "
+":py:class:`neomaril_codex.model.NeomarilModel` para chamar o modelo."
 
-#: ../../source/deploying.rst:124
+#: ../../source/deploying.rst:167
 msgid ""
 "Sync models return a dictionary and async models return a "
 ":py:class:`neomaril_codex.base.NeomarilExecution` that you can use to "
 "check the status and download the result similiar to the training "
 "execution."
 msgstr ""
-"Modelos síncronos retornar um dicionário e modelos assíncronos retorna uma "
-":py:class:`neomaril_codex.base.NeomarilExecution` que pode ser usada para "
-"verificar o status e fazer o download do resultado, similar ao contexto da execução de "
-"treinamento."
+"Modelos síncronos retornar um dicionário e modelos assíncronos retorna "
+"uma :py:class:`neomaril_codex.base.NeomarilExecution` que pode ser usada "
+"para verificar o status e fazer o download do resultado, similar ao "
+"contexto da execução de treinamento."
 
-#: ../../source/deploying.rst:126
+#: ../../source/deploying.rst:169
 msgid ""
 "To use the models you need a `group token`, that is generated when "
 "creating the group (check :ref:`connecting_to_neomaril:creating a "
@@ -209,14 +222,15 @@ msgid ""
 "or add in each :py:meth:`neomaril_codex.model.NeomarilModel.predict` "
 "call."
 msgstr ""
-"Para usar os modelos você precisa de um `group token`, que é gerado no momento "
-"de criação do grupo (verifique :ref:`connecting_to_neomaril:creating a "
-"group`). Você pode adicionar esse token à variável de ambiente NEOMARIL_GROUP_TOKEN,"
-" usando o método :py:meth:`neomaril_codex.model.NeomarilModel.set_token`, "
-"ou então adicionar em cada chamada ao método "
+"Para usar os modelos você precisa de um `group token`, que é gerado no "
+"momento de criação do grupo (verifique "
+":ref:`connecting_to_neomaril:creating a group`). Você pode adicionar esse"
+" token à variável de ambiente NEOMARIL_GROUP_TOKEN, usando o método "
+":py:meth:`neomaril_codex.model.NeomarilModel.set_token`, ou então "
+"adicionar em cada chamada ao método "
 ":py:meth:`neomaril_codex.model.NeomarilModel.predict`."
 
-#: ../../source/deploying.rst:129
+#: ../../source/deploying.rst:172
 msgid ""
 "Most of the time you might need to used your model outside a python "
 "environment, sharing it through a REST API. You can call the "
@@ -226,55 +240,121 @@ msgid ""
 "method to create a sample request code to your model."
 msgstr ""
 "A maior parte do tempo você precisará usar seu modelo fora do ambiente "
-"Python, compartilhando através da API REST. Você pode chamar o "
-"atributo :py:attr:`neomaril_codex.model.NeomarilModel.docs` para compartilhar uma "
+"Python, compartilhando através da API REST. Você pode chamar o atributo "
+":py:attr:`neomaril_codex.model.NeomarilModel.docs` para compartilhar uma "
 "página no formato OpenAPI Swagger, ou então usar o método "
-":py:meth:`neomaril_codex.model.NeomarilModel.generate_predict_code` "
-"para criar o código de exemplo de uma requisição para o modelo."
+":py:meth:`neomaril_codex.model.NeomarilModel.generate_predict_code` para "
+"criar o código de exemplo de uma requisição para o modelo."
 
-#: ../../source/deploying.rst:134
+#: ../../source/deploying.rst:177
 msgid "Monitoring your model"
 msgstr "Monitorando seu modelo"
 
-#: ../../source/deploying.rst:136
+#: ../../source/deploying.rst:179
+#, fuzzy
 msgid ""
-"Model monitoring means keeping track with how the model is being used in "
-"production so we can update the model if it start making bad predictions."
+"Model monitoring means keeping track of how the model is being used in "
+"production, so you can update it if it starts making bad predictions."
 msgstr ""
 "Monitorar o modelo significa entender como este está se comportanto em "
-"produção, de forma a entender se é o momento de atualiza-lo devido ao nível de predições erradas."
+"produção, de forma a entender se é o momento de atualiza-lo devido ao "
+"nível de predições erradas."
 
-#: ../../source/deploying.rst:138
+#: ../../source/deploying.rst:181
+#, fuzzy
 msgid ""
-"For now Neomaril only does indirect monitoring, that means following the "
-"input of the model in production and checking if is close to the data "
-"presented to the model in training. So when configure the monitoring we "
-"need to know which training generated that model and what features are "
-"relevant to monitoring the model."
+"For now, Neomaril only does indirect monitoring. This means that Neomaril"
+" follows the input of the model in production and checks if it is close "
+"to the data presented to the model in training. So, when configuring the "
+"monitoring system, we need to know which training generated that model "
+"and what features are relevant to monitoring the model."
 msgstr ""
-"Atualmente, o Neomaril faz apenas o monitoramento indireto. Isso significa acompanhar a "
-"entrada do modelo em produção e verificar se está próxima dos dados "
-"apresentados no treinamento. Então, quando configuramos o monitoramento nós "
-"precisamos saber quais dados de treinamento geraram o modelo, e quais features são "
-"relevantes para o processo de monitoramento."
+"Atualmente, o Neomaril faz apenas o monitoramento indireto. Isso "
+"significa acompanhar a entrada do modelo em produção e verificar se está "
+"próxima dos dados apresentados no treinamento. Então, quando configuramos"
+" o monitoramento nós precisamos saber quais dados de treinamento geraram "
+"o modelo, e quais features são relevantes para o processo de "
+"monitoramento."
 
-#: ../../source/deploying.rst:141
-msgid "Besides we need to know how to handle the features and the model."
-msgstr "Além disso, precisamos saber como lidar tanto com as features quanto com o modelo."
+#: ../../source/deploying.rst:184
+msgid ""
+"We offer both \"Population Stability Index\" (PSI and PSI average) and "
+"\"SHapley Additive exPlanations\" (SHAP and SHAP average) metrics."
+msgstr ""
 
-#: ../../source/deploying.rst:143
+#: ../../source/deploying.rst:186
+#, fuzzy
+msgid ""
+"Besides that, we need to know how to correctly handle the features and "
+"the model."
+msgstr ""
+"Além disso, precisamos saber como lidar tanto com as features quanto com "
+"o modelo."
+
+#: ../../source/deploying.rst:188
+#, fuzzy
 msgid ""
 "The production data is saved raw, and the training data is not (check "
 ":ref:`training_guide:Running a training execution`). So we need to know "
-"the steps in processing the raw data to get the model features like the "
-"ones we saved during training:"
+"the steps in processing the raw production data to get the model features"
+" like the ones we saved during training: "
+":ref:`monitoring_parameters:Monitoring configuration`"
 msgstr ""
-"Os dados de produção são salvos em formato cru (raw), mas os dados de treinamento não (verifique "
-":ref:`training_guide:Running a training execution`). Então, precisamos saber "
-"quais são os passos no processamento dos dados crus para obter as features do modelo, como "
-"foi feito durante o treinamento:"
+"Os dados de produção são salvos em formato cru (raw), mas os dados de "
+"treinamento não (verifique :ref:`training_guide:Running a training "
+"execution`). Então, precisamos saber quais são os passos no processamento"
+" dos dados crus para obter as features do modelo, como foi feito durante "
+"o treinamento:"
 
-#: ../../source/deploying.rst:145
-msgid "**TBD in the preprocess module.**"
-msgstr "**TBD no módulo de pré-processamento.**"
+#: ../../source/deploying.rst:190
+msgid ""
+"The first method you need to call is "
+":py:meth:`neomaril_codex.pipeline.NeomarilPipeline.register_monitoring_config`,"
+" which is responsible for registering the monitoring configuration at the"
+" database."
+msgstr ""
+"O primeiro método que precisa ser chamado é "
+":py:meth:`neomaril_codex.pipeline.NeomarilPipeline.register_monitoring_config`,"
+" que é responsável por registrar a configuração de monitoramento no"
+" banco de dados."
+
+#: ../../source/deploying.rst:192
+msgid ""
+"Next, you can manually run the monitoring process, calling the method "
+":py:meth:`neomaril_codex.pipeline.NeomarilPipeline.run_monitoring`."
+msgstr ""
+"Em seguida, você pode executar manualmente o processo de monitoramento, chamado o método "
+":py:meth:`neomaril_codex.pipeline.NeomarilPipeline.run_monitoring`."
+
+#: ../../source/deploying.rst:196
+msgid "Using with preprocess script"
+msgstr "Usando o script de preprocessamento"
+
+#: ../../source/deploying.rst:198
+msgid ""
+"Sometimes you want to run a preprocess script to adjust the model input "
+"data before executing it. With Neomaril you can do it."
+msgstr ""
+"Algumas vezes você quer executar um script de preprocessamento para ajustar a entrada do modelo "
+"antes de executá-lo. Com o Neomaril você consegue fazer isso."
+
+#: ../../source/deploying.rst:200
+msgid ""
+"You must first instantiate the "
+":py:class:`neomaril_codex.base.NeomarilExecution`:"
+msgstr ""
+"Você deve primeiramente instanciar o "
+":py:class:`neomaril_codex.base.NeomarilExecution`:"
+
+#: ../../source/deploying.rst:209
+msgid ""
+"And now you just need to run the model using the preprocess script (check"
+" :ref:`preprocessing:Preprocessing module`). For the **sync model**:"
+msgstr ""
+"E agora você deve executar o modelo usando o script de preprocessamento (verifique"
+" :ref:`preprocessing:Preprocessing module`). Para o **modelo sync**:"
+
+#: ../../source/deploying.rst:221
+msgid "And for the **async model**:"
+msgstr "E para o **modelo assíncrono**:"
 

--- a/docs/source/locale/pt_BR/LC_MESSAGES/deploying.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/deploying.po
@@ -87,7 +87,7 @@ msgstr ""
 #: ../../source/deploying.rst:31
 msgid ""
 "**Async model:** This is for batch scoring. We send files with usually a "
-"lot o records at once. Since this might take a while depeding on the file"
+"lot of records at once. Since this might take a while depeding on the file"
 " size, we run this asynchronously. The entrypoint function should look "
 "like this:"
 msgstr ""

--- a/docs/source/locale/pt_BR/LC_MESSAGES/model.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/model.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomaril-codex \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-05 15:49-0300\n"
+"POT-Creation-Date: 2023-12-04 12:08-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: pt\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.12.1\n"
+"Generated-By: Babel 2.13.1\n"
 
 #: ../../source/model.rst:2
 msgid "Model module"
@@ -29,14 +29,626 @@ msgid ""
 "Module with all classes and methods to manage the Machine Learning (ML) "
 "models deployed at Neomaril."
 msgstr ""
-"Módulo com todas as classes e métodos para gerenciar os modelos de Machine Learning (ML) "
-"implantados no Neomaril."
+"Módulo com todas as classes e métodos para gerenciar os modelos de "
+"Machine Learning (ML) implantados no Neomaril."
 
 #: ../../source/model.rst:9
 msgid "neomaril\\_codex.model.NeomarilModel"
 msgstr "neomaril\\_codex.model.NeomarilModel"
 
+#: neomaril_codex.model.NeomarilModel:1 of
+msgid "Bases: :py:class:`~neomaril_codex.base.BaseNeomaril`"
+msgstr "Bases: :py:class:`~neomaril_codex.base.BaseNeomaril`"
+
+#: neomaril_codex.model.NeomarilModel:1 of
+msgid "Class to manage Models deployed inside Neomaril"
+msgstr "Classe usada para gerenciar os modelos implantados dentro do Neomaril"
+
+#: neomaril_codex.model.NeomarilModel:5
+#: neomaril_codex.model.NeomarilModelClient:5 of
+msgid ""
+"Login for authenticating with the client. You can also use the env "
+"variable NEOMARIL_USER to set this"
+msgstr ""
+"Use o login para autenticar com o cliente. Você também pode usar a variável "
+"de ambiente NEOMARIL_USER para configurar isto"
+
+#: neomaril_codex.model.NeomarilModel neomaril_codex.model.NeomarilModelClient
+#: of
+msgid "type"
+msgstr "type"
+
+#: neomaril_codex.model.NeomarilModel:-1 neomaril_codex.model.NeomarilModel:7
+#: neomaril_codex.model.NeomarilModel:13
+#: neomaril_codex.model.NeomarilModelClient:7
+#: neomaril_codex.model.NeomarilModelClient:13
+#: neomaril_codex.model.NeomarilModelClient:19 of
+msgid "str"
+msgstr "str"
+
+#: neomaril_codex.model.NeomarilModel:11
+#: neomaril_codex.model.NeomarilModelClient:11 of
+msgid ""
+"Password for authenticating with the client. You can also use the env "
+"variable NEOMARIL_PASSWORD to set this"
+msgstr ""
+"Senha para autenticar com o cliente. Você também pode usar a variável "
+"de ambiente NEOMARIL_PASSWORD para configurar isto"
+
+#: neomaril_codex.model.NeomarilModel:15 of
+#, fuzzy
+msgid "model_id"
+msgstr "Módulo do modelo"
+
+#: neomaril_codex.model.NeomarilModel:16 of
+msgid "Model id (hash) from the model you want to access"
+msgstr "ID do modelo (hash) para o modelo que você deseja acessar"
+
+#: neomaril_codex.model.NeomarilModel:17 of
+msgid "group"
+msgstr "grupo"
+
+#: neomaril_codex.model.NeomarilModel:18
+#: neomaril_codex.model.NeomarilModelClient.get_model:5 of
+msgid "Group the model is inserted. Default is 'datarisk' (public group)"
+msgstr "Grupo que o modelo está inserido. O valor padrão é 'datarisk' (grupo público)"
+
+#: neomaril_codex.model.NeomarilModel:19 of
+msgid "group_token"
+msgstr "group_token"
+
+#: neomaril_codex.model.NeomarilModel:20
+#: neomaril_codex.model.NeomarilModel.predict:7
+#: neomaril_codex.model.NeomarilModelClient.get_model:7 of
+msgid ""
+"Token for executing the model (show when creating a group). It can be "
+"informed when getting the model or when running predictions, or using the"
+" env variable NEOMARIL_GROUP_TOKEN"
+msgstr ""
+"Token para executar o modelo (mostrado na criação do grupo). Ele pode ser "
+"informado quando recebe-se o modelo ou quando são executadas as predições, ou usando a"
+" variável de ambiente NEOMARIL_GROUP_TOKEN"
+
+#: neomaril_codex.model.NeomarilModel:21 of
+msgid "url"
+msgstr "url"
+
+#: neomaril_codex.model.NeomarilModel:22
+#: neomaril_codex.model.NeomarilModelClient:17 of
+msgid ""
+"URL to Neomaril Server. Default value is "
+"https://neomaril.staging.datarisk.net, use it to test your deployment "
+"first before changing to production. You can also use the env variable "
+"NEOMARIL_URL to set this"
+msgstr ""
+"URL para o servidor do Neomaril. O valor padrão é "
+"https://neomaril.staging.datarisk.net, use ele para testar seu deployment "
+"antes de mover para produção. Você também pode usar a variável de ambiente "
+"NEOMARIL_URL para configurar isto"
+
+#: neomaril_codex.model.NeomarilModel:24 of
+msgid "docs"
+msgstr "docs"
+
+#: neomaril_codex.model.NeomarilModel:24 of
+msgid "URL for the model Swagger page"
+msgstr "URL para a página Swagger do modelo"
+
+#: neomaril_codex.model.NeomarilModel neomaril_codex.model.NeomarilModel.delete
+#: neomaril_codex.model.NeomarilModel.generate_predict_code
+#: neomaril_codex.model.NeomarilModel.get_logs
+#: neomaril_codex.model.NeomarilModel.get_model_execution
+#: neomaril_codex.model.NeomarilModel.predict
+#: neomaril_codex.model.NeomarilModel.register_monitoring
+#: neomaril_codex.model.NeomarilModelClient
+#: neomaril_codex.model.NeomarilModelClient.create_model
+#: neomaril_codex.model.NeomarilModelClient.get_logs
+#: neomaril_codex.model.NeomarilModelClient.get_model
+#: neomaril_codex.model.NeomarilModelClient.search_models of
+msgid "Raises"
+msgstr "Raises"
+
+#: neomaril_codex.model.NeomarilModel:26 of
+msgid "When the model can't be acessed in the server"
+msgstr "Quando o modelo não pode ser acessado no servidor"
+
+#: neomaril_codex.model.NeomarilModel:27
+#: neomaril_codex.model.NeomarilModelClient:21 of
+msgid "Unvalid credentials"
+msgstr "Credenciais inválidas"
+
+#: neomaril_codex.model.NeomarilModel:30
+#: neomaril_codex.model.NeomarilModel.delete:10
+#: neomaril_codex.model.NeomarilModel.get_logs:18
+#: neomaril_codex.model.NeomarilModel.get_model_execution:9
+#: neomaril_codex.model.NeomarilModel.health:8
+#: neomaril_codex.model.NeomarilModel.register_monitoring:20
+#: neomaril_codex.model.NeomarilModel.restart_model:7
+#: neomaril_codex.model.NeomarilModel.set_token:7
+#: neomaril_codex.model.NeomarilModel.wait_ready:4
+#: neomaril_codex.model.NeomarilModelClient:25
+#: neomaril_codex.model.NeomarilModelClient.create_model:36
+#: neomaril_codex.model.NeomarilModelClient.get_logs:20
+#: neomaril_codex.model.NeomarilModelClient.get_model:19
+#: neomaril_codex.model.NeomarilModelClient.get_model_execution:14
+#: neomaril_codex.model.NeomarilModelClient.search_models:18 of
+msgid "Example"
+msgstr "Exemplo"
+
+#: neomaril_codex.model.NeomarilModel:31 of
+msgid "Getting a model, testint its healthy and putting it to run the prediction"
+msgstr "Getting a model, testint its healthy and putting it to run the prediction"
+
+#: neomaril_codex.model.NeomarilModel.delete:1 of
+msgid ""
+"Deletes the current model. IMPORTANT! For now this is irreversible, if "
+"you want to use the model again later you will need to upload again (and "
+"it will have a new ID)."
+msgstr ""
+"Deleta o modelo atual. IMPORTANTE! Por agora essa ação é irreversível, se "
+"você quer continuar a usar o modelo no futuro, será necessário carregar novamente seus arquivos (e "
+"ele receberá um novo ID)."
+
+#: neomaril_codex.model.NeomarilModel.delete:4 of
+msgid "Model deleting failed"
+msgstr "Model deleting failed"
+
+#: neomaril_codex.model.NeomarilModel.delete
+#: neomaril_codex.model.NeomarilModel.generate_predict_code
+#: neomaril_codex.model.NeomarilModel.get_logs
+#: neomaril_codex.model.NeomarilModel.health
+#: neomaril_codex.model.NeomarilModel.predict
+#: neomaril_codex.model.NeomarilModel.register_monitoring
+#: neomaril_codex.model.NeomarilModelClient.create_model
+#: neomaril_codex.model.NeomarilModelClient.get_logs
+#: neomaril_codex.model.NeomarilModelClient.get_model
+#: neomaril_codex.model.NeomarilModelClient.get_model_execution
+#: neomaril_codex.model.NeomarilModelClient.search_models of
+msgid "Returns"
+msgstr "Returns"
+
+#: neomaril_codex.model.NeomarilModel.delete:6 of
+msgid ""
+"If model is at status=Deployed deletes the model and return a json with "
+"his information. If it isn't Deployed it returns the message that the "
+"model is under another state"
+msgstr ""
+"Se o modelo estiver no status=Deployed, será deletado o modelo e o retorno será um json com "
+"suas informações. Se ele não estiver no status Deployed, será retornada uma mensagem de que "
+"o modelo está num outro estado"
+
+#: neomaril_codex.model.NeomarilModel.delete
+#: neomaril_codex.model.NeomarilModel.generate_predict_code
+#: neomaril_codex.model.NeomarilModel.get_logs
+#: neomaril_codex.model.NeomarilModel.health
+#: neomaril_codex.model.NeomarilModel.predict
+#: neomaril_codex.model.NeomarilModel.register_monitoring
+#: neomaril_codex.model.NeomarilModelClient.create_model
+#: neomaril_codex.model.NeomarilModelClient.get_logs
+#: neomaril_codex.model.NeomarilModelClient.get_model
+#: neomaril_codex.model.NeomarilModelClient.get_model_execution
+#: neomaril_codex.model.NeomarilModelClient.search_models of
+msgid "Return type"
+msgstr "Return type"
+
+#: neomaril_codex.model.NeomarilModel.generate_predict_code:1 of
+msgid "Generates predict code for the model to be used outside Neomaril Codex"
+msgstr "Gera o código de predição para o modelo usado fora do Neomaril Codex"
+
+#: neomaril_codex.model.NeomarilModel.generate_predict_code
+#: neomaril_codex.model.NeomarilModel.get_logs
+#: neomaril_codex.model.NeomarilModel.get_model_execution
+#: neomaril_codex.model.NeomarilModel.predict
+#: neomaril_codex.model.NeomarilModel.register_monitoring
+#: neomaril_codex.model.NeomarilModel.restart_model
+#: neomaril_codex.model.NeomarilModel.set_token
+#: neomaril_codex.model.NeomarilModelClient.create_model
+#: neomaril_codex.model.NeomarilModelClient.get_logs
+#: neomaril_codex.model.NeomarilModelClient.get_model
+#: neomaril_codex.model.NeomarilModelClient.get_model_execution
+#: neomaril_codex.model.NeomarilModelClient.search_models of
+msgid "Parameters"
+msgstr "Parameters"
+
+#: neomaril_codex.model.NeomarilModel.generate_predict_code:3 of
+msgid ""
+"The generated code language. Supported languages are 'curl', 'python' or "
+"'javascript'"
+msgstr ""
+"The generated code language. Supported languages are 'curl', 'python' or "
+"'javascript'"
+
+#: neomaril_codex.model.NeomarilModel.generate_predict_code:6 of
+msgid "Unsupported language"
+msgstr "Linguagem não suportada"
+
+#: neomaril_codex.model.NeomarilModel.generate_predict_code:8 of
+msgid "The generated code."
+msgstr "O código gerado."
+
+#: neomaril_codex.model.NeomarilModel.get_logs:1
+#: neomaril_codex.model.NeomarilModelClient.get_logs:1 of
+msgid "Get the logs"
+msgstr "Receba os logs"
+
+#: neomaril_codex.model.NeomarilModel.get_logs:3
+#: neomaril_codex.model.NeomarilModelClient.get_logs:5 of
+msgid "Date to start filter. At the format aaaa-mm-dd"
+msgstr "Data para iniciar o filtro. No formato aaaa-mm-dd"
+
+#: neomaril_codex.model.NeomarilModel.get_logs:5
+#: neomaril_codex.model.NeomarilModelClient.get_logs:7 of
+msgid "Date to end filter. At the format aaaa-mm-dd"
+msgstr "Data para finalizar o filtro. No formato aaaa-mm-dd"
+
+#: neomaril_codex.model.NeomarilModel.get_logs:7 of
+msgid "Type of routine beeing executed, can assume values Host or Run"
+msgstr "Tipo da rotina sendo executada, pode ter os valores Host ou Run"
+
+#: neomaril_codex.model.NeomarilModel.get_logs:9 of
+msgid ""
+"Defines the type of the logs that are going to be filtered, can assume "
+"the values Ok, Error, Debug or Warning"
+msgstr ""
+"Define o tipo dos logs que serão filtrados, pode assumir "
+"os valores Ok, Error, Debug ou Warning"
+
+#: neomaril_codex.model.NeomarilModel.get_logs:12
+#: neomaril_codex.model.NeomarilModelClient.get_logs:14
+#: neomaril_codex.model.NeomarilModelClient.search_models:12 of
+msgid "Unexpected server error"
+msgstr "Unexpected server error"
+
+#: neomaril_codex.model.NeomarilModel.get_logs:14
+#: neomaril_codex.model.NeomarilModelClient.get_logs:16 of
+msgid "Logs list"
+msgstr "List de logs"
+
+#: neomaril_codex.model.NeomarilModel.get_model_execution:1 of
+msgid "Get a execution instace for that model."
+msgstr "Recebe a instância da execução do modelo."
+
+#: neomaril_codex.model.NeomarilModel.get_model_execution:3
+#: neomaril_codex.model.NeomarilModelClient.get_model_execution:5 of
+msgid "Execution id"
+msgstr "Execution id"
+
+#: neomaril_codex.model.NeomarilModel.get_model_execution:6 of
+msgid "If the user tries to get a execution from a Sync model"
+msgstr "Se o usuário tentar receber uma execução de um modelo Sync"
+
+#: neomaril_codex.model.NeomarilModel.health:1 of
+msgid "Get the model deployment process health state."
+msgstr "Recebe o estado de saúde do processo de implantação do modelo"
+
+#: neomaril_codex.model.NeomarilModel.health:3 of
+msgid ""
+"OK - if the it is possible to get the health state NOK - if an exception "
+"occurs"
+msgstr ""
+"OK - if the it is possible to get the health state NOK - if an exception "
+"occurs"
+
+#: neomaril_codex.model.NeomarilModel.predict:1 of
+msgid "Runs a prediction from the current model."
+msgstr "Executa uma predição com o modelo atual"
+
+#: neomaril_codex.model.NeomarilModel.predict:3 of
+msgid ""
+"The same data that is used in the source file. If Sync is a dict, the "
+"keys that are needed inside this dict are the ones in the `schema` "
+"atribute. If Async is a string with the file path with the same filename "
+"used in the source file."
+msgstr ""
+"Os mesmos dados que são usados no arquivo fonte. Se Sync é um dict, as "
+"chaves que são necessárias dentro deste dict são aquelas no atributo "
+"`schema`. Se Async é uma string com o caminho do arquivo com o mesmo nome "
+"usado no arquivo fonte."
+
+#: neomaril_codex.model.NeomarilModel.predict:9 of
+msgid ""
+"Boolean that informs if a model training is completed (True) or not "
+"(False). Default value is False"
+msgstr ""
+"Booleano que informa se um treinamento do modelo está completo (True) ou não "
+"(False). O valor padrão é False"
+
+#: neomaril_codex.model.NeomarilModel.predict:12 of
+msgid "Model is not available"
+msgstr "Modelo não está disponível"
+
+#: neomaril_codex.model.NeomarilModel.predict:14 of
+msgid ""
+"The return of the scoring function in the source file for Sync models or "
+"the execution class for Async models."
+msgstr ""
+"O retorno da função de escoragem no arquivo fonte para modelos Sync ou "
+"a classe de execução para modelos Async."
+
+#: neomaril_codex.model.NeomarilModel.register_monitoring:1 of
+msgid "Register the model monitoring configuration at the database"
+msgstr "Registra a configuração de monitoramento do modelo no banco de dados"
+
+#: neomaril_codex.model.NeomarilModel.register_monitoring:3 of
+msgid "Name of the preprocess reference"
+msgstr "Nome da referência de preprocessamento"
+
+#: neomaril_codex.model.NeomarilModel.register_monitoring:5 of
+msgid "Name of the preprocess function"
+msgstr "Nome da função de preprocessamento"
+
+#: neomaril_codex.model.NeomarilModel.register_monitoring:7 of
+msgid "Path of the configuration file, but it could be a dict"
+msgstr "Caminho do arquivo de configuração, mas pode ser um dict"
+
+#: neomaril_codex.model.NeomarilModel.register_monitoring:9 of
+msgid "Path of the preprocess script"
+msgstr "Caminho para o script de preprocessamento"
+
+#: neomaril_codex.model.NeomarilModel.register_monitoring:11 of
+msgid "Path of the requirements file"
+msgstr "Caminho para o arquivo requirements"
+
+#: neomaril_codex.model.NeomarilModel.register_monitoring:14 of
+msgid "Invalid parameters for model creation"
+msgstr "Parâmetros inválidos para a criação do modelo"
+
+#: neomaril_codex.model.NeomarilModel.register_monitoring:16
+#: neomaril_codex.model.NeomarilModelClient.get_logs:3
+#: neomaril_codex.model.NeomarilModelClient.get_model_execution:3 of
+msgid "Model id (hash)"
+msgstr "Model id (hash)"
+
+#: neomaril_codex.model.NeomarilModel.restart_model:1 of
+msgid "Restart a model deployment process health state."
+msgstr "Reinicia o estado de saúde do processo de implantação de um modelo."
+
+#: neomaril_codex.model.NeomarilModel.restart_model:3
+#: neomaril_codex.model.NeomarilModelClient.get_model:9 of
+msgid ""
+"If the model is being deployed, wait for it to be ready instead of "
+"failing the request. Defaults to True"
+msgstr ""
+"Se o modelo está sendo implantado, espera para que ele esteja pronto em vez de "
+"falhar a requisição. O valor padrão é True"
+
+#: neomaril_codex.model.NeomarilModel.set_token:1 of
+msgid "Saves the group token for this model instance."
+msgstr "Salva o token do grupo para essa instância do modelo."
+
+#: neomaril_codex.model.NeomarilModel.set_token:3 of
+msgid ""
+"Token for executing the model (show when creating a group). You can set "
+"this using the NEOMARIL_GROUP_TOKEN env variable"
+msgstr ""
+
+#: neomaril_codex.model.NeomarilModel.wait_ready:1 of
+msgid "Waits the model to be with status 'Deployed'"
+msgstr "Espera o modelo ter o status 'Deployed'"
+
 #: ../../source/model.rst:18
 msgid "neomaril\\_codex.model.NeomarilModelClient"
 msgstr "neomaril\\_codex.model.NeomarilModelClient"
+
+#: neomaril_codex.model.NeomarilModelClient:1 of
+#, fuzzy
+msgid "Bases: :py:class:`~neomaril_codex.base.BaseNeomarilClient`"
+msgstr "Bases: :py:class:`~neomaril_codex.base.BaseNeomarilClient`"
+
+#: neomaril_codex.model.NeomarilModelClient:1 of
+msgid "Class for client to access Neomaril and manage models"
+msgstr "Classe para que o cliente acesse o Neomaril e gerencie modelos"
+
+#: neomaril_codex.model.NeomarilModelClient:22 of
+msgid "Server unavailable"
+msgstr "Server unavailable"
+
+#: neomaril_codex.model.NeomarilModelClient:26 of
+msgid "Example 1: Creation and managing a Synchronous Model"
+msgstr "Exemplo 1: Criação e gerenciamento de um modelo Síncrono"
+
+#: neomaril_codex.model.NeomarilModelClient:72 of
+msgid "Example 2: creation and deployment of a Asynchronous Model"
+msgstr "Exemplo 2: Criação e gerenciamento de um modelo Assíncrono"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:1 of
+msgid "Deploy a new model to Neomaril."
+msgstr "Implantação de um novo modelo no Neomaril."
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:3 of
+msgid "The name of the model, in less than 32 characters"
+msgstr "O nome do modelo, em menos que 32 caracteres"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:5 of
+msgid "The name of the scoring function inside the source file"
+msgstr "O nome da função de escoragem dentro do arquivo fonte"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:7 of
+msgid ""
+"Path of the source file. The file must have a scoring function that "
+"accepts two parameters: data (data for the request body of the model) and"
+" model_path (absolute path of where the file is located)"
+msgstr ""
+"Caminho do arquivo fonte. O arquivo deve ter uma função de escoragem que "
+"aceita dois parâmetros: data (dados para o corpo da requisição do modelo) e"
+" model_path (caminho absoluto de onde o arquivo está localizado)"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:9 of
+msgid "Path of the model pkl file"
+msgstr "Caminho do arquivo pkl do modelo"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:11 of
+msgid ""
+"Path of the requirements file. The packages versions must be fixed eg: "
+"pandas==1.0"
+msgstr ""
+"Caminho para o arquivo de requirements. As versões dos pacotes devem ser fixadas ex: "
+"pandas==1.0"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:13 of
+msgid ""
+"Path to a JSON or XML file with a sample of the input for the entrypoint "
+"function. A dict with the sample input can be send as well. Mandatory for"
+" Sync models"
+msgstr ""
+"Caminho para um arquivo JSON ou XML com um exemplo de entrada para a função "
+"entrypoint. Um dict com um exemplo de entrada pode ser enviado também. Mandatório para"
+" modelos Sync"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:15 of
+msgid "Group the model is inserted. Default to 'datarisk' (public group)"
+msgstr "Grupo que o modelo é inserido. O valor padrão é 'datarisk' (grupo público)"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:17 of
+msgid ""
+"A optional list with additional files paths that should be uploaded. If "
+"the scoring function refer to this file they will be on the same folder "
+"as the source file"
+msgstr ""
+"A optional list with additional files paths that should be uploaded. If "
+"the scoring function refer to this file they will be on the same folder "
+"as the source file"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:19 of
+msgid ""
+".env file to be used in your model enviroment. This will be encrypted in "
+"the server."
+msgstr ""
+".env file to be used in your model enviroment. This will be encrypted in "
+"the server."
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:21 of
+msgid ""
+"Python version for the model environment. Avaliable versions are 3.7, "
+"3.8, 3.9, 3.10. Defaults to '3.8'"
+msgstr ""
+"Python version for the model environment. Avaliable versions are 3.7, "
+"3.8, 3.9, 3.10. Defaults to '3.8'"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:23 of
+msgid ""
+"Defines wich kind operation is beeing executed (Sync or Async). Default "
+"value is Sync"
+msgstr ""
+"Defines wich kind operation is beeing executed (Sync or Async). Default "
+"value is Sync"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:25 of
+msgid "The type of the input file that should be 'json', 'csv' or 'parquet'"
+msgstr "The type of the input file that should be 'json', 'csv' or 'parquet'"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:27 of
+msgid ""
+"Wait for model to be ready and returns a NeomarilModel instace with the "
+"new model. Defaults to True"
+msgstr ""
+"Wait for model to be ready and returns a NeomarilModel instace with the "
+"new model. Defaults to True"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:30 of
+msgid "Some input parameters its invalid"
+msgstr "Some input parameters its invalid"
+
+#: neomaril_codex.model.NeomarilModelClient.create_model:32 of
+msgid ""
+"Returns the new model, if wait_for_ready=True runs the deploy process "
+"synchronously. If its False, returns nothing after sending all the data "
+"to server and runs the deploy asynchronously"
+msgstr ""
+"Returns the new model, if wait_for_ready=True runs the deploy process "
+"synchronously. If its False, returns nothing after sending all the data "
+"to server and runs the deploy asynchronously"
+
+#: neomaril_codex.model.NeomarilModelClient.get_logs:9 of
+msgid ""
+"Type of routine being executed, can assume values 'Host' (for deployment "
+"logs) or 'Run' (for execution logs)"
+msgstr ""
+"Type of routine being executed, can assume values 'Host' (for deployment "
+"logs) or 'Run' (for execution logs)"
+
+#: neomaril_codex.model.NeomarilModelClient.get_logs:11 of
+msgid ""
+"Defines the type of the logs that are going to be filtered, can assume "
+"the values 'Ok', 'Error', 'Debug' or 'Warning'"
+msgstr ""
+"Defines the type of the logs that are going to be filtered, can assume "
+"the values 'Ok', 'Error', 'Debug' or 'Warning'"
+
+#: neomaril_codex.model.NeomarilModelClient.get_model:1 of
+msgid "Acess a model using its id"
+msgstr "Acess a model using its id"
+
+#: neomaril_codex.model.NeomarilModelClient.get_model:3 of
+msgid "Model id (hash) that needs to be acessed"
+msgstr "Model id (hash) that needs to be acessed"
+
+#: neomaril_codex.model.NeomarilModelClient.get_model:12 of
+#, fuzzy
+msgid "Model unavailable"
+msgstr "Módulo do modelo"
+
+#: neomaril_codex.model.NeomarilModelClient.get_model:13 of
+msgid "Unknown return from server"
+msgstr "Unknown return from server"
+
+#: neomaril_codex.model.NeomarilModelClient.get_model:15 of
+msgid "A NeomarilModel instance with the model hash from `model_id`"
+msgstr "A NeomarilModel instance with the model hash from `model_id`"
+
+#: neomaril_codex.model.NeomarilModelClient.get_model_execution:1 of
+msgid "Get a execution instace (Async model only)."
+msgstr "Get a execution instace (Async model only)."
+
+#: neomaril_codex.model.NeomarilModelClient.get_model_execution:7 of
+msgid "Group name, default value is None"
+msgstr "Group name, default value is None"
+
+#: neomaril_codex.model.NeomarilModelClient.get_model_execution:10 of
+msgid "The new execution"
+msgstr "The new execution"
+
+#: neomaril_codex.model.NeomarilModelClient.search_models:1 of
+msgid "Search for models using the name of the model"
+msgstr "Search for models using the name of the model"
+
+#: neomaril_codex.model.NeomarilModelClient.search_models:3 of
+msgid ""
+"Text that its expected to be on the model name. It runs similar to a LIKE"
+" query on SQL"
+msgstr ""
+"Text that its expected to be on the model name. It runs similar to a LIKE"
+" query on SQL"
+
+#: neomaril_codex.model.NeomarilModelClient.search_models:5 of
+msgid ""
+"Text that its expected to be on the state. It runs similar to a LIKE "
+"query on SQL"
+msgstr ""
+"Text that its expected to be on the state. It runs similar to a LIKE "
+"query on SQL"
+
+#: neomaril_codex.model.NeomarilModelClient.search_models:7 of
+msgid ""
+"Text that its expected to be on the group name. It runs similar to a LIKE"
+" query on SQL"
+msgstr ""
+"Text that its expected to be on the group name. It runs similar to a LIKE"
+" query on SQL"
+
+#: neomaril_codex.model.NeomarilModelClient.search_models:9 of
+msgid ""
+"If its True, filter only models ready to be used (status == "
+"\"Deployed\"). Defaults to False"
+msgstr ""
+"If its True, filter only models ready to be used (status == "
+"\"Deployed\"). Defaults to False"
+
+#: neomaril_codex.model.NeomarilModelClient.search_models:14 of
+msgid ""
+"List with the models data, it can works like a filter depending on the "
+"arguments values"
+msgstr ""
+"List with the models data, it can works like a filter depending on the "
+"arguments values"
 

--- a/docs/source/locale/pt_BR/LC_MESSAGES/monitoring_parameters.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/monitoring_parameters.po
@@ -1,0 +1,74 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Datarisk
+# This file is distributed under the same license as the neomaril-codex
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: neomaril-codex \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-12-04 12:08-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pt_BR\n"
+"Language-Team: pt_BR <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.1\n"
+
+#: ../../source/monitoring_parameters.rst:4
+msgid "Monitoring configuration"
+msgstr "Configuração do monitoramento"
+
+#: ../../source/monitoring_parameters.rst:14
+msgid "{"
+msgstr "{}"
+
+#: ../../source/monitoring_parameters.rst:8
+msgid ""
+"\"period\": \"week\", <string, Mandatory> indicates monitoring frequency "
+"running. Can be `day`, `week`, `month` or `year` \"train_data\" : {"
+msgstr ""
+"\"period\": \"week\", <string, Mandatory> indicates monitoring frequency "
+"running. Can be `day`, `week`, `month` or `year` \"train_data\" : {"
+
+#: ../../source/monitoring_parameters.rst:10
+msgid ""
+"\"NeomarilTrainingExecution\": \"1\", <string, Mandatory for model "
+"trained inside Neomaril> executionId from training promoted at Neomaril "
+"// \"train_date_col\": \"date\", <string, Mandatory if no field "
+"\"train_date_ref\" was inserted> name of the date column for the records "
+"\"train_date_ref\": \"2022-09-01\", <string, Mandatory if no field "
+"\"train_date_col\" was inserted> date the model data was acquired"
+msgstr ""
+"\"NeomarilTrainingExecution\": \"1\", <string, Mandatory for model "
+"trained inside Neomaril> executionId from training promoted at Neomaril "
+"// \"train_date_col\": \"date\", <string, Mandatory if no field "
+"\"train_date_ref\" was inserted> name of the date column for the records "
+"\"train_date_ref\": \"2022-09-01\", <string, Mandatory if no field "
+"\"train_date_col\" was inserted> date the model data was acquired"
+
+#: ../../source/monitoring_parameters.rst:13
+msgid ""
+"} \"input_cols\": [\"mean_radius\", \"mean_texture\"] , <list[string]> "
+"name of the features columns that the monitoring will run. Need to be the"
+" same of the train data in MLFlow and the output of the pre-process "
+"function \"output_cols\": [\"proba\", \"pred\"] , <list[string]> name of "
+"the output columns that the monitoring will run. Need to be the same of "
+"the output data in MLFlow and the output of the model scoring function"
+msgstr ""
+"} \"input_cols\": [\"mean_radius\", \"mean_texture\"] , <list[string]> "
+"name of the features columns that the monitoring will run. Need to be the"
+" same of the train data in MLFlow and the output of the pre-process "
+"function \"output_cols\": [\"proba\", \"pred\"] , <list[string]> name of "
+"the output columns that the monitoring will run. Need to be the same of "
+"the output data in MLFlow and the output of the model scoring function"
+
+#: ../../source/monitoring_parameters.rst:16
+msgid "}"
+msgstr "}"
+

--- a/docs/source/locale/pt_BR/LC_MESSAGES/pipeline.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/pipeline.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomaril-codex \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-05 15:49-0300\n"
+"POT-Creation-Date: 2023-12-04 12:08-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: pt\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.12.1\n"
+"Generated-By: Babel 2.13.1\n"
 
 #: ../../source/pipeline.rst:2
 msgid "Pipeline module"
@@ -31,4 +31,206 @@ msgstr "Este módulo permite que você configure a pipeline do seu modelo."
 #: ../../source/pipeline.rst:9
 msgid "neomaril\\_codex.pipeline.NeomarilPipeline"
 msgstr "neomaril\\_codex.pipeline.NeomarilPipeline"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:1 of
+msgid "Bases: :py:class:`object`"
+msgstr "Bases: :py:class:`object`"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:1 of
+msgid ""
+"Class to construct and orchestrates the flow data of the models inside "
+"Neomaril."
+msgstr ""
+"Class to construct and orchestrates the flow data of the models inside "
+"Neomaril."
+
+#: neomaril_codex.pipeline.NeomarilPipeline:4 of
+msgid "Atributtes"
+msgstr "Atributtes"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:5 of
+msgid "login"
+msgstr "login"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:-1 of
+msgid "str"
+msgstr "str"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:6 of
+msgid ""
+"Login for authenticating with the client. You can also use the env "
+"variable NEOMARIL_USER to set this"
+msgstr ""
+"Login for authenticating with the client. You can also use the env "
+"variable NEOMARIL_USER to set this"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:7 of
+msgid "password"
+msgstr "password"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:8 of
+msgid ""
+"Password for authenticating with the client. You can also use the env "
+"variable NEOMARIL_PASSWORD to set this"
+msgstr ""
+"Password for authenticating with the client. You can also use the env "
+"variable NEOMARIL_PASSWORD to set this"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:9 of
+msgid "group"
+msgstr "group"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:10 of
+msgid "Group the model is inserted"
+msgstr "Group the model is inserted"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:11 of
+msgid "url"
+msgstr "url"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:12 of
+msgid ""
+"URL to Neomaril Server. Default value is "
+"https://neomaril.staging.datarisk.net, use it to test your deployment "
+"first before changing to production. You can also use the env variable "
+"NEOMARIL_URL to set this"
+msgstr ""
+"URL to Neomaril Server. Default value is "
+"https://neomaril.staging.datarisk.net, use it to test your deployment "
+"first before changing to production. You can also use the env variable "
+"NEOMARIL_URL to set this"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:14 of
+msgid "python_version"
+msgstr "python_version"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:14 of
+msgid ""
+"Python version for the model environment. Avaliable versions are 3.7, "
+"3.8, 3.9, 3.10. Defaults to '3.9'"
+msgstr ""
+"Python version for the model environment. Avaliable versions are 3.7, "
+"3.8, 3.9, 3.10. Defaults to '3.9'"
+
+#: neomaril_codex.pipeline.NeomarilPipeline:17
+#: neomaril_codex.pipeline.NeomarilPipeline.from_config_file:12
+#: neomaril_codex.pipeline.NeomarilPipeline.register_monitoring_config:7
+#: neomaril_codex.pipeline.NeomarilPipeline.run_deploy:12
+#: neomaril_codex.pipeline.NeomarilPipeline.run_monitoring:9
+#: neomaril_codex.pipeline.NeomarilPipeline.run_training:9
+#: neomaril_codex.pipeline.NeomarilPipeline.start:6 of
+msgid "Example"
+msgstr "Example"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.from_config_file:1 of
+msgid "Load the configuration files for orchestrate the model"
+msgstr "Load the configuration files for orchestrate the model"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.from_config_file
+#: neomaril_codex.pipeline.NeomarilPipeline.register_deploy_config
+#: neomaril_codex.pipeline.NeomarilPipeline.register_monitoring_config
+#: neomaril_codex.pipeline.NeomarilPipeline.register_train_config
+#: neomaril_codex.pipeline.NeomarilPipeline.run_deploy
+#: neomaril_codex.pipeline.NeomarilPipeline.run_monitoring of
+msgid "Parameters"
+msgstr "Parameters"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.from_config_file:3 of
+msgid "Path of the configuration file, but it could be a dict"
+msgstr "Path of the configuration file, but it could be a dict"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.from_config_file
+#: neomaril_codex.pipeline.NeomarilPipeline.run_deploy
+#: neomaril_codex.pipeline.NeomarilPipeline.run_training
+#: neomaril_codex.pipeline.NeomarilPipeline.start of
+msgid "Raises"
+msgstr "Raises"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.from_config_file:6 of
+msgid "Undefined credentials"
+msgstr "Undefined credentials"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.from_config_file
+#: neomaril_codex.pipeline.NeomarilPipeline.run_deploy
+#: neomaril_codex.pipeline.NeomarilPipeline.run_training of
+msgid "Returns"
+msgstr "Returns"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.from_config_file:8 of
+msgid "The new pipeline"
+msgstr "The new pipeline"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.from_config_file
+#: neomaril_codex.pipeline.NeomarilPipeline.run_deploy
+#: neomaril_codex.pipeline.NeomarilPipeline.run_training of
+msgid "Return type"
+msgstr "Return type"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.register_deploy_config:1 of
+msgid "Set the files for configure the deploy"
+msgstr "Set the files for configure the deploy"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.register_deploy_config:3 of
+msgid "List or dictionary with the necessary files for deploy"
+msgstr "List or dictionary with the necessary files for deploy"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.register_monitoring_config:1 of
+msgid "Set the files for configure the monitoring"
+msgstr "Set the files for configure the monitoring"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.register_monitoring_config:3 of
+msgid "List or dictionary with the necessary files for monitoring"
+msgstr "List or dictionary with the necessary files for monitoring"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.register_train_config:1 of
+msgid "Set the files for configure the training"
+msgstr "Set the files for configure the training"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.register_train_config:3 of
+msgid "List or dictionary with the necessary files for training"
+msgstr "List or dictionary with the necessary files for training"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.run_deploy:1 of
+msgid "Run the deploy process"
+msgstr "Run the deploy process"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.run_deploy:3 of
+msgid "The id for the training process that you want to deploy now"
+msgstr "The id for the training process that you want to deploy now"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.run_deploy:6 of
+msgid "Deploy has failed"
+msgstr "Deploy has failed"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.run_deploy:8 of
+msgid "The new Model id (hash)"
+msgstr "The new Model id (hash)"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.run_monitoring:1 of
+msgid "Run the monitoring process"
+msgstr "Run the monitoring process"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.run_monitoring:3 of
+msgid "The id for the training execution process that you want to monitore now"
+msgstr "The id for the training execution process that you want to monitore now"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.run_training:1 of
+msgid "Run the training process"
+msgstr "Run the training process"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.run_training:3 of
+msgid "Training has failed"
+msgstr "Training has failed"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.run_training:5 of
+msgid "A tuple with the 'training_id' and the 'exec_id'"
+msgstr "A tuple with the 'training_id' and the 'exec_id'"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.start:1 of
+msgid "Start the pipeline for the model orchestration"
+msgstr "Start the pipeline for the model orchestration"
+
+#: neomaril_codex.pipeline.NeomarilPipeline.start:3 of
+msgid "Cannot start pipeline without configuration"
+msgstr "Cannot start pipeline without configuration"
 

--- a/docs/source/locale/pt_BR/LC_MESSAGES/preprocessing.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/preprocessing.po
@@ -1,0 +1,563 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2023, Datarisk
+# This file is distributed under the same license as the neomaril-codex
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: neomaril-codex \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-12-04 12:08-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pt_BR\n"
+"Language-Team: pt_BR <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.1\n"
+
+#: ../../source/preprocessing.rst:2
+msgid "Preprocessing module"
+msgstr "Módulo de preprocessamento"
+
+#: ../../source/preprocessing.rst:5
+msgid ""
+"Module with all classes and methods to manage the Preprocessing scripts "
+"deployed at Neomaril."
+msgstr ""
+"Module with all classes and methods to manage the Preprocessing scripts "
+"deployed at Neomaril."
+
+#: ../../source/preprocessing.rst:9
+msgid "neomaril\\_codex.preprocessing.NeomarilPreprocessing"
+msgstr "neomaril\\_codex.preprocessing.NeomarilPreprocessing"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:1 of
+msgid "Bases: :py:class:`~neomaril_codex.base.BaseNeomaril`"
+msgstr "Bases: :py:class:`~neomaril_codex.base.BaseNeomaril`"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:1 of
+msgid "Class to manage Preprocessing scripts deployed inside Neomaril"
+msgstr "Class to manage Preprocessing scripts deployed inside Neomaril"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:5
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:5 of
+msgid ""
+"Login for authenticating with the client. You can also use the env "
+"variable NEOMARIL_USER to set this"
+msgstr ""
+"Login for authenticating with the client. You can also use the env "
+"variable NEOMARIL_USER to set this"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient of
+msgid "type"
+msgstr "type"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:-1
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:7
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:13
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:7
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:13
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:19 of
+msgid "str"
+msgstr "str"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:11
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:11 of
+msgid ""
+"Password for authenticating with the client. You can also use the env "
+"variable NEOMARIL_PASSWORD to set this"
+msgstr ""
+"Password for authenticating with the client. You can also use the env "
+"variable NEOMARIL_PASSWORD to set this"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:15 of
+msgid "preprocessing_id"
+msgstr "preprocessing_id"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:16 of
+msgid "Preprocessing script id (hash) from the script you want to access"
+msgstr "Preprocessing script id (hash) from the script you want to access"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:17 of
+msgid "group"
+msgstr "group"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:18 of
+msgid "Group the model is inserted. Default is 'datarisk' (public group)"
+msgstr "Group the model is inserted. Default is 'datarisk' (public group)"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:20 of
+msgid "base_url"
+msgstr "base_url"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:20
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:17 of
+msgid ""
+"URL to Neomaril Server. Default value is "
+"https://neomaril.staging.datarisk.net, use it to test your deployment "
+"first before changing to production. You can also use the env variable "
+"NEOMARIL_URL to set this"
+msgstr ""
+"URL to Neomaril Server. Default value is "
+"https://neomaril.staging.datarisk.net, use it to test your deployment "
+"first before changing to production. You can also use the env variable "
+"NEOMARIL_URL to set this"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:23
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_logs:18
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_preprocessing_execution:9
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.set_token:7
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.wait_ready:4
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:25
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:34
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_execution:14
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs:20
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing:19
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.search_preprocessing:18
+#: of
+msgid "Example"
+msgstr "Example"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing:24 of
+msgid "Getting a model, testint its healthy and putting it to run the prediction"
+msgstr "Getting a model, testint its healthy and putting it to run the prediction"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_logs:1
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs:1 of
+msgid "Get the logs"
+msgstr "Get the logs"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_logs
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_preprocessing_execution
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.run
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.set_token
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_execution
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.search_preprocessing
+#: of
+msgid "Parameters"
+msgstr "Parameters"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_logs:3
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs:5 of
+msgid "Date to start filter. At the format aaaa-mm-dd"
+msgstr "Date to start filter. At the format aaaa-mm-dd"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_logs:5
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs:7 of
+msgid "Date to end filter. At the format aaaa-mm-dd"
+msgstr "Date to end filter. At the format aaaa-mm-dd"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_logs:7 of
+msgid "Type of routine beeing executed, can assume values Host or Run"
+msgstr "Type of routine beeing executed, can assume values Host or Run"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_logs:9 of
+msgid ""
+"Defines the type of the logs that are going to be filtered, can assume "
+"the values Ok, Error, Debug or Warning"
+msgstr ""
+"Defines the type of the logs that are going to be filtered, can assume "
+"the values Ok, Error, Debug or Warning"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_logs
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_preprocessing_execution
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.run
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.search_preprocessing
+#: of
+msgid "Raises"
+msgstr "Raises"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_logs:12
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs:14
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.search_preprocessing:12
+#: of
+msgid "Unexpected server error"
+msgstr "Unexpected server error"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_logs
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.run
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_execution
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.search_preprocessing
+#: of
+msgid "Returns"
+msgstr "Returns"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_logs:14
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs:16 of
+msgid "Logs list"
+msgstr "Logs list"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_logs
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.run
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_execution
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.search_preprocessing
+#: of
+msgid "Return type"
+msgstr "Return type"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_preprocessing_execution:1
+#: of
+msgid "Get a execution instance for that pre processing."
+msgstr "Get a execution instance for that pre processing."
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_preprocessing_execution:3
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_execution:5 of
+msgid "Execution id"
+msgstr "Execution id"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.get_preprocessing_execution:6
+#: of
+msgid "If the user tries to get a execution from a Sync pre processing"
+msgstr "If the user tries to get a execution from a Sync pre processing"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.run:1 of
+msgid "Runs a prediction from the current pre processing."
+msgstr "Runs a prediction from the current pre processing."
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.run:3 of
+msgid ""
+"The same data that is used in the source file. If Sync is a dict, the "
+"keys that are needed inside this dict are the ones in the `schema` "
+"atribute. If Async is a string with the file path with the same filename "
+"used in the source file."
+msgstr ""
+"The same data that is used in the source file. If Sync is a dict, the "
+"keys that are needed inside this dict are the ones in the `schema` "
+"atribute. If Async is a string with the file path with the same filename "
+"used in the source file."
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.run:7
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing:7
+#: of
+msgid ""
+"Token for executing the pre processing (show when creating a group). It "
+"can be informed when getting the preprocessing or when running "
+"predictions, or using the env variable NEOMARIL_GROUP_TOKEN"
+msgstr ""
+"Token for executing the pre processing (show when creating a group). It "
+"can be informed when getting the preprocessing or when running "
+"predictions, or using the env variable NEOMARIL_GROUP_TOKEN"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.run:9 of
+msgid ""
+"Boolean that informs if a pre processing training is completed (True) or "
+"not (False). Default value is False"
+msgstr ""
+"Boolean that informs if a pre processing training is completed (True) or "
+"not (False). Default value is False"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.run:12 of
+msgid "Pre processing is not available"
+msgstr "Pre processing is not available"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.run:14 of
+msgid ""
+"The return of the scoring function in the source file for Sync pre "
+"processing or the execution class for Async pre processing."
+msgstr ""
+"The return of the scoring function in the source file for Sync pre "
+"processing or the execution class for Async pre processing."
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.set_token:1 of
+msgid "Saves the group token for this pre processing instance."
+msgstr "Saves the group token for this pre processing instance."
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.set_token:3 of
+msgid ""
+"Token for executing the pre processing (show when creating a group). You "
+"can set this using the NEOMARIL_GROUP_TOKEN env variable"
+msgstr ""
+"Token for executing the pre processing (show when creating a group). You "
+"can set this using the NEOMARIL_GROUP_TOKEN env variable"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessing.wait_ready:1 of
+msgid "Waits the pre processing to be with status 'Deployed'"
+msgstr "Waits the pre processing to be with status 'Deployed'"
+
+#: ../../source/preprocessing.rst:18
+msgid "neomaril\\_codex.preprocessing.NeomarilPreprocessingClient"
+msgstr "neomaril\\_codex.preprocessing.NeomarilPreprocessingClient"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:1 of
+msgid "Bases: :py:class:`~neomaril_codex.base.BaseNeomarilClient`"
+msgstr "Bases: :py:class:`~neomaril_codex.base.BaseNeomarilClient`"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:1 of
+msgid "Class for client to access Neomaril and manage Preprocessing scripts"
+msgstr "Class for client to access Neomaril and manage Preprocessing scripts"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:21 of
+msgid "Unvalid credentials"
+msgstr "Unvalid credentials"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:22 of
+msgid "Server unavailable"
+msgstr "Server unavailable"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:26 of
+msgid "Example 1: Creation and managing a Synchronous Preprocess script"
+msgstr "Example 1: Creation and managing a Synchronous Preprocess script"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:53 of
+msgid "Example 2: creation and deployment of an Asynchronous Preprocess script"
+msgstr "Example 2: creation and deployment of an Asynchronous Preprocess script"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:85 of
+msgid "Example 3: Using preprocessing with a Synchronous model"
+msgstr "Example 3: Using preprocessing with a Synchronous model"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient:101 of
+msgid "Example 4: Using preprocessing with an Asynchronous model"
+msgstr "Example 4: Using preprocessing with an Asynchronous model"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:1 of
+msgid "Deploy a new preprocessing to Neomaril."
+msgstr "Deploy a new preprocessing to Neomaril."
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:3 of
+msgid "The name of the pre processing, in less than 32 characters"
+msgstr "The name of the pre processing, in less than 32 characters"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:5 of
+msgid "The name of the scoring function inside the source file"
+msgstr "The name of the scoring function inside the source file"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:7 of
+msgid ""
+"Path of the source file. The file must have a scoring function that "
+"accepts two parameters: data (data for the request body of the "
+"preprocessing) and preprocessing_path (absolute path of where the file is"
+" located)"
+msgstr ""
+"Path of the source file. The file must have a scoring function that "
+"accepts two parameters: data (data for the request body of the "
+"preprocessing) and preprocessing_path (absolute path of where the file is"
+" located)"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:9 of
+msgid ""
+"Path of the requirements file. The packages versions must be fixed eg: "
+"pandas==1.0"
+msgstr ""
+"Path of the requirements file. The packages versions must be fixed eg: "
+"pandas==1.0"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:11 of
+msgid ""
+"Path to a JSON or XML file with a sample of the input for the entrypoint "
+"function. A dict with the sample input can be send as well. Mandatory for"
+" Sync preprocessing"
+msgstr ""
+"Path to a JSON or XML file with a sample of the input for the entrypoint "
+"function. A dict with the sample input can be send as well. Mandatory for"
+" Sync preprocessing"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:13 of
+msgid "Group the pre processing is inserted. Default to 'datarisk' (public group)"
+msgstr "Group the pre processing is inserted. Default to 'datarisk' (public group)"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:15 of
+msgid ""
+"A optional list with additional files paths that should be uploaded. If "
+"the scoring function refer to this file they will be on the same folder "
+"as the source file"
+msgstr ""
+"A optional list with additional files paths that should be uploaded. If "
+"the scoring function refer to this file they will be on the same folder "
+"as the source file"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:17 of
+msgid ""
+"Flag that choose which environment (dev, staging, production) of Neomaril"
+" you are using. Default is True"
+msgstr ""
+"Flag that choose which environment (dev, staging, production) of Neomaril"
+" you are using. Default is True"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:19 of
+msgid ""
+"Python version for the pre processing environment. Avaliable versions are"
+" 3.7, 3.8, 3.9, 3.10. Defaults to '3.8'"
+msgstr ""
+"Python version for the pre processing environment. Avaliable versions are"
+" 3.7, 3.8, 3.9, 3.10. Defaults to '3.8'"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:21 of
+msgid ""
+"Defines wich kind operation is beeing executed (Sync or Async). Default "
+"value is Sync"
+msgstr ""
+"Defines wich kind operation is beeing executed (Sync or Async). Default "
+"value is Sync"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:23 of
+msgid "The type of the input file that should be 'json', 'csv' or 'parquet'"
+msgstr "The type of the input file that should be 'json', 'csv' or 'parquet'"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:25 of
+msgid ""
+"Wait for preprocessing to be ready and returns a NeomarilPreprocessing "
+"instace with the new preprocessing. Defaults to True"
+msgstr ""
+"Wait for preprocessing to be ready and returns a NeomarilPreprocessing "
+"instace with the new preprocessing. Defaults to True"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:28 of
+msgid "Some input parameters its invalid"
+msgstr "Some input parameters its invalid"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:30 of
+msgid ""
+"Returns the new preprocessing, if wait_for_ready=True runs the deploy "
+"process synchronously. If its False, returns nothing after sending all "
+"the data to server and runs the deploy asynchronously"
+msgstr ""
+"Returns the new preprocessing, if wait_for_ready=True runs the deploy "
+"process synchronously. If its False, returns nothing after sending all "
+"the data to server and runs the deploy asynchronously"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_execution:1 of
+msgid "Get a execution instace (Async pre processing only)."
+msgstr "Get a execution instace (Async pre processing only)."
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_execution:3
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs:3 of
+msgid "Pre processing id (hash)"
+msgstr "Pre processing id (hash)"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_execution:7 of
+msgid "Group name, default value is None"
+msgstr "Group name, default value is None"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_execution:10 of
+msgid "The new execution"
+msgstr "The new execution"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs:9 of
+msgid ""
+"Type of routine being executed, can assume values 'Host' (for deployment "
+"logs) or 'Run' (for execution logs)"
+msgstr ""
+"Type of routine being executed, can assume values 'Host' (for deployment "
+"logs) or 'Run' (for execution logs)"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_logs:11 of
+msgid ""
+"Defines the type of the logs that are going to be filtered, can assume "
+"the values 'Ok', 'Error', 'Debug' or 'Warning'"
+msgstr ""
+"Defines the type of the logs that are going to be filtered, can assume "
+"the values 'Ok', 'Error', 'Debug' or 'Warning'"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing:1
+#: of
+msgid "Access a pre processing using its id"
+msgstr "Access a pre processing using its id"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing:3
+#: of
+msgid "Pre processing id (hash) that needs to be accessed"
+msgstr "Pre processing id (hash) that needs to be accessed"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing:5
+#: of
+msgid "Group the pre processing is inserted. Default is 'datarisk' (public group)"
+msgstr "Group the pre processing is inserted. Default is 'datarisk' (public group)"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing:9
+#: of
+msgid ""
+"If the pre processing is being deployed, wait for it to be ready instead "
+"of failing the request. Defaults to True"
+msgstr ""
+"If the pre processing is being deployed, wait for it to be ready instead "
+"of failing the request. Defaults to True"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing:12
+#: of
+msgid "Pre processing unavailable"
+msgstr "Pre processing unavailable"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing:13
+#: of
+msgid "Unknown return from server"
+msgstr "Unknown return from server"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.get_preprocessing:15
+#: of
+msgid ""
+"A NeomarilPreprocessing instance with the pre processing hash from "
+"`preprocessing_id`"
+msgstr ""
+"A NeomarilPreprocessing instance with the pre processing hash from "
+"`preprocessing_id`"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.search_preprocessing:1
+#: of
+msgid "Search for pre processing using the name of the pre processing"
+msgstr "Search for pre processing using the name of the pre processing"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.search_preprocessing:3
+#: of
+msgid ""
+"Text that its expected to be on the pre processing name. It runs similar "
+"to a LIKE query on SQL"
+msgstr ""
+"Text that its expected to be on the pre processing name. It runs similar "
+"to a LIKE query on SQL"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.search_preprocessing:5
+#: of
+msgid ""
+"Text that its expected to be on the state. It runs similar to a LIKE "
+"query on SQL"
+msgstr ""
+"Text that its expected to be on the state. It runs similar to a LIKE "
+"query on SQL"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.search_preprocessing:7
+#: of
+msgid ""
+"Text that its expected to be on the group name. It runs similar to a LIKE"
+" query on SQL"
+msgstr ""
+"Text that its expected to be on the group name. It runs similar to a LIKE"
+" query on SQL"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.search_preprocessing:9
+#: of
+msgid ""
+"If its True, filter only pre processing ready to be used (status == "
+"\"Deployed\"). Defaults to False"
+msgstr ""
+"If its True, filter only pre processing ready to be used (status == "
+"\"Deployed\"). Defaults to False"
+
+#: neomaril_codex.preprocessing.NeomarilPreprocessingClient.search_preprocessing:14
+#: of
+msgid ""
+"List with the pre processing data, it can works like a filter depending "
+"on the arguments values"
+msgstr ""
+"List with the pre processing data, it can works like a filter depending "
+"on the arguments values"
+

--- a/docs/source/locale/pt_BR/LC_MESSAGES/training.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/training.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomaril-codex \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-05 15:49-0300\n"
+"POT-Creation-Date: 2023-12-04 12:08-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: pt\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.12.1\n"
+"Generated-By: Babel 2.13.1\n"
 
 #: ../../source/training.rst:2
 msgid "Training module"
@@ -26,17 +26,490 @@ msgstr "Módulo de treinamento"
 
 #: ../../source/training.rst:5
 msgid "Module with the classes that alows to manage your trainining experiments."
-msgstr "Módulo com as classes que permitem gerenciar seus experimentos de treinamento."
+msgstr ""
+"Módulo com as classes que permitem gerenciar seus experimentos de "
+"treinamento."
 
 #: ../../source/training.rst:9
 msgid "neomaril\\_codex.training.NeomarilTrainingExecution"
 msgstr "neomaril\\_codex.training.NeomarilTrainingExecution"
 
+#: neomaril_codex.training.NeomarilTrainingExecution:1 of
+#, fuzzy
+msgid "Bases: :py:class:`~neomaril_codex.base.NeomarilExecution`"
+msgstr "Bases: :py:class:`~neomaril_codex.base.NeomarilExecution`"
+
+#: neomaril_codex.training.NeomarilTrainingExecution:1 of
+msgid "Class to manage trained models."
+msgstr "Class to manage trained models."
+
+#: neomaril_codex.training.NeomarilTrainingExecution:5
+#: neomaril_codex.training.NeomarilTrainingExperiment:16 of
+msgid "Training id (hash) from the experiment you want to access"
+msgstr "Training id (hash) from the experiment you want to access"
+
+#: neomaril_codex.training.NeomarilTrainingClient
+#: neomaril_codex.training.NeomarilTrainingExecution
+#: neomaril_codex.training.NeomarilTrainingExperiment of
+msgid "type"
+msgstr "type"
+
+#: neomaril_codex.training.NeomarilTrainingClient:7
+#: neomaril_codex.training.NeomarilTrainingClient:13
+#: neomaril_codex.training.NeomarilTrainingClient:19
+#: neomaril_codex.training.NeomarilTrainingExecution:-1
+#: neomaril_codex.training.NeomarilTrainingExecution:7
+#: neomaril_codex.training.NeomarilTrainingExecution:13
+#: neomaril_codex.training.NeomarilTrainingExecution:23
+#: neomaril_codex.training.NeomarilTrainingExecution:29
+#: neomaril_codex.training.NeomarilTrainingExperiment:-1
+#: neomaril_codex.training.NeomarilTrainingExperiment:7
+#: neomaril_codex.training.NeomarilTrainingExperiment:13 of
+msgid "str"
+msgstr "str"
+
+#: neomaril_codex.training.NeomarilTrainingExecution:11
+#: neomaril_codex.training.NeomarilTrainingExperiment:18 of
+msgid "Group the training is inserted. Default is 'datarisk' (public group)"
+msgstr "Group the training is inserted. Default is 'datarisk' (public group)"
+
+#: neomaril_codex.training.NeomarilTrainingExecution:17 of
+msgid "Executiong id for that especific training run login : str"
+msgstr "Executiong id for that especific training run login : str"
+
+#: neomaril_codex.training.NeomarilTrainingClient:5
+#: neomaril_codex.training.NeomarilTrainingExecution:19
+#: neomaril_codex.training.NeomarilTrainingExperiment:5 of
+msgid ""
+"Login for authenticating with the client. You can also use the env "
+"variable NEOMARIL_USER to set this"
+msgstr ""
+"Login for authenticating with the client. You can also use the env "
+"variable NEOMARIL_USER to set this"
+
+#: neomaril_codex.training.NeomarilTrainingExecution:21 of
+msgid "password"
+msgstr "password"
+
+#: neomaril_codex.training.NeomarilTrainingClient:11
+#: neomaril_codex.training.NeomarilTrainingExecution:21
+#: neomaril_codex.training.NeomarilTrainingExperiment:11 of
+msgid ""
+"Password for authenticating with the client. You can also use the env "
+"variable NEOMARIL_PASSWORD to set this"
+msgstr ""
+"Password for authenticating with the client. You can also use the env "
+"variable NEOMARIL_PASSWORD to set this"
+
+#: neomaril_codex.training.NeomarilTrainingExecution:27 of
+msgid "Enviroment of Neomaril you are using."
+msgstr "Enviroment of Neomaril you are using."
+
+#: neomaril_codex.training.NeomarilTrainingExecution:33 of
+msgid "Metadata from the execution."
+msgstr "Metadata from the execution."
+
+#: neomaril_codex.training.NeomarilTrainingExecution:35 of
+msgid "dict"
+msgstr "dict"
+
+#: neomaril_codex.training.NeomarilTrainingClient
+#: neomaril_codex.training.NeomarilTrainingClient.create_training_experiment
+#: neomaril_codex.training.NeomarilTrainingClient.get_training
+#: neomaril_codex.training.NeomarilTrainingExecution
+#: neomaril_codex.training.NeomarilTrainingExecution.get_status
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model
+#: neomaril_codex.training.NeomarilTrainingExperiment
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training of
+msgid "Raises"
+msgstr "Raises"
+
+#: neomaril_codex.training.NeomarilTrainingExecution:37
+#: neomaril_codex.training.NeomarilTrainingExperiment:25 of
+msgid "When the training can't be acessed in the server"
+msgstr "When the training can't be acessed in the server"
+
+#: neomaril_codex.training.NeomarilTrainingClient:21
+#: neomaril_codex.training.NeomarilTrainingExecution:38
+#: neomaril_codex.training.NeomarilTrainingExperiment:26 of
+msgid "Unvalid credentials"
+msgstr "Unvalid credentials"
+
+#: neomaril_codex.training.NeomarilTrainingClient:25
+#: neomaril_codex.training.NeomarilTrainingClient.create_training_experiment:17
+#: neomaril_codex.training.NeomarilTrainingClient.get_training:15
+#: neomaril_codex.training.NeomarilTrainingExecution:41
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:28
+#: neomaril_codex.training.NeomarilTrainingExperiment:29
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:34 of
+msgid "Example"
+msgstr "Example"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.get_status:1 of
+msgid "Gets the status of the related execution."
+msgstr "Gets the status of the related execution."
+
+#: neomaril_codex.training.NeomarilTrainingExecution.get_status:3 of
+msgid "Execution unavailable"
+msgstr "Execution unavailable"
+
+#: neomaril_codex.training.NeomarilTrainingClient.create_training_experiment
+#: neomaril_codex.training.NeomarilTrainingClient.get_training
+#: neomaril_codex.training.NeomarilTrainingExecution.get_status
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model
+#: neomaril_codex.training.NeomarilTrainingExperiment.get_all_training_executions
+#: neomaril_codex.training.NeomarilTrainingExperiment.get_training_execution
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training of
+msgid "Returns"
+msgstr "Returns"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.get_status:5 of
+msgid "Returns the execution status."
+msgstr "Returns the execution status."
+
+#: neomaril_codex.training.NeomarilTrainingClient.create_training_experiment
+#: neomaril_codex.training.NeomarilTrainingClient.get_training
+#: neomaril_codex.training.NeomarilTrainingExecution.get_status
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model
+#: neomaril_codex.training.NeomarilTrainingExperiment.get_all_training_executions
+#: neomaril_codex.training.NeomarilTrainingExperiment.get_training_execution
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training of
+msgid "Return type"
+msgstr "Return type"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:1 of
+msgid "Upload models trained inside Neomaril."
+msgstr "Upload models trained inside Neomaril."
+
+#: neomaril_codex.training.NeomarilTrainingClient.create_training_experiment
+#: neomaril_codex.training.NeomarilTrainingClient.get_training
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model
+#: neomaril_codex.training.NeomarilTrainingExperiment.get_training_execution
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training of
+msgid "Parameters"
+msgstr "Parameters"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:3
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:3 of
+msgid "The name of the model, in less than 32 characters"
+msgstr "The name of the model, in less than 32 characters"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:5 of
+msgid "The name of the scoring function inside the source file"
+msgstr "The name of the scoring function inside the source file"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:7 of
+msgid ""
+"Path of the source file. The file must have a scoring function that "
+"accepts two parameters: data (data for the request body of the model) and"
+" model_path (absolute path of where the file is located)"
+msgstr ""
+"Path of the source file. The file must have a scoring function that "
+"accepts two parameters: data (data for the request body of the model) and"
+" model_path (absolute path of where the file is located)"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:9 of
+msgid ""
+"Path to a JSON or XML file with a sample of the input for the entrypoint "
+"function. A dict with the sample input can be send as well"
+msgstr ""
+"Path to a JSON or XML file with a sample of the input for the entrypoint "
+"function. A dict with the sample input can be send as well"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:11
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:12 of
+msgid ""
+"A optional list with additional files paths that should be uploaded. If "
+"the scoring function refer to this file they will be on the same folder "
+"as the source file"
+msgstr ""
+"A optional list with additional files paths that should be uploaded. If "
+"the scoring function refer to this file they will be on the same folder "
+"as the source file"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:13 of
+msgid ""
+"Path of the requirements file. This will override the requirements used "
+"in trainning. The packages versions must be fixed eg: pandas==1.0"
+msgstr ""
+"Path of the requirements file. This will override the requirements used "
+"in trainning. The packages versions must be fixed eg: pandas==1.0"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:15 of
+msgid ""
+"Flag that choose which environment (dev, staging, production) of Neomaril"
+" you are using. Default is True"
+msgstr ""
+"Flag that choose which environment (dev, staging, production) of Neomaril"
+" you are using. Default is True"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:17 of
+msgid ""
+"Defines wich kind operation is beeing executed (Sync or Async). Default "
+"value is Sync"
+msgstr ""
+"Defines wich kind operation is beeing executed (Sync or Async). Default "
+"value is Sync"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:19 of
+msgid "The type of the input file that should be 'json', 'csv' or 'parquet'"
+msgstr "The type of the input file that should be 'json', 'csv' or 'parquet'"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:22 of
+msgid "The training execution shouldn't be succeeded to be promoted"
+msgstr "The training execution shouldn't be succeeded to be promoted"
+
+#: neomaril_codex.training.NeomarilTrainingExecution.promote_model:24 of
+#, fuzzy
+msgid "The new training model"
+msgstr "Módulo de treinamento"
+
 #: ../../source/training.rst:18
 msgid "neomaril\\_codex.training.NeomarilTrainingExperiment"
 msgstr "neomaril\\_codex.training.NeomarilTrainingExperiment"
 
+#: neomaril_codex.training.NeomarilTrainingExperiment:1 of
+msgid "Bases: :py:class:`~neomaril_codex.base.BaseNeomaril`"
+msgstr "Bases: :py:class:`~neomaril_codex.base.BaseNeomaril`"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment:1 of
+msgid "Class to manage models being trained inside Neomaril"
+msgstr "Class to manage models being trained inside Neomaril"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment:15 of
+#, fuzzy
+msgid "training_id"
+msgstr "training_id"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment:17 of
+msgid "group"
+msgstr "group"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment:19 of
+msgid "environment"
+msgstr "environment"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment:20 of
+msgid ""
+"Flag that choose which environment of Neomaril you are using. Test your "
+"deployment first before changing to production. Default is True"
+msgstr ""
+"Flag that choose which environment of Neomaril you are using. Test your "
+"deployment first before changing to production. Default is True"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment:23 of
+msgid "executions"
+msgstr "executions"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment:-1 of
+msgid "List[int]"
+msgstr "List[int]"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment:22 of
+msgid "Ids for the executions in that training"
+msgstr "Ids for the executions in that training"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.get_all_training_executions:1
+#: of
+msgid "Get all executions from that experiment."
+msgstr "Get all executions from that experiment."
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.get_all_training_executions:3
+#: of
+msgid "All executions from that training"
+msgstr "All executions from that training"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.get_training_execution:1
+#: of
+msgid "Get a execution instace."
+msgstr "Get a execution instace."
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.get_training_execution:3
+#: of
+msgid "Execution id. If not informed we get the last execution."
+msgstr "Execution id. If not informed we get the last execution."
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.get_training_execution:6
+#: of
+msgid "The choosen execution"
+msgstr "The choosen execution"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:1 of
+msgid "Runs a prediction from the current model."
+msgstr "Runs a prediction from the current model."
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:5 of
+msgid "Path of the file with train data."
+msgstr "Path of the file with train data."
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:7 of
+msgid ""
+"The name of the training function inside the source file. Just used when "
+"training_type is Custom"
+msgstr ""
+"The name of the training function inside the source file. Just used when "
+"training_type is Custom"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:9 of
+msgid "Can be Custom, AutoML or External"
+msgstr "Can be Custom, AutoML or External"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:11 of
+msgid "Description of the experiment"
+msgstr "Description of the experiment"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:13 of
+msgid ""
+"Python version for the model environment. Avaliable versions are 3.7, "
+"3.8, 3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom"
+msgstr ""
+"Python version for the model environment. Avaliable versions are 3.7, "
+"3.8, 3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:15 of
+msgid ""
+"Path to a JSON file with a the AutoML configuration. A dict can be send "
+"as well. Just used when training_type is AutoML"
+msgstr ""
+"Path to a JSON file with a the AutoML configuration. A dict can be send "
+"as well. Just used when training_type is AutoML"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:17 of
+msgid ""
+"Path of the source file. The file must have a training function that "
+"accepts one parameter: model_path (absolute path of where the file is "
+"located). Just used when training_type is Custom"
+msgstr ""
+"Path of the source file. The file must have a training function that "
+"accepts one parameter: model_path (absolute path of where the file is "
+"located). Just used when training_type is Custom"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:19 of
+msgid ""
+"Path of the requirements file. The packages versions must be fixed eg: "
+"pandas==1.0. Just used when training_type is Custom"
+msgstr ""
+"Path of the requirements file. The packages versions must be fixed eg: "
+"pandas==1.0. Just used when training_type is Custom"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:21 of
+msgid ""
+".env file to be used in your training enviroment. This will be encrypted "
+"in the server."
+msgstr ""
+".env file to be used in your training enviroment. This will be encrypted "
+"in the server."
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:23 of
+msgid ""
+"A optional list with additional files paths that should be uploaded. If "
+"the scoring function refer to this file they will be on the same folder "
+"as the source file. Just used when training_type is Custom"
+msgstr ""
+"A optional list with additional files paths that should be uploaded. If "
+"the scoring function refer to this file they will be on the same folder "
+"as the source file. Just used when training_type is Custom"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:25 of
+msgid ""
+"Boolean that informs if a model training is completed (True) or not "
+"(False). Default value is False"
+msgstr ""
+"Boolean that informs if a model training is completed (True) or not "
+"(False). Default value is False"
+
+#: neomaril_codex.training.NeomarilTrainingClient.create_training_experiment:10
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:28 of
+msgid "Some input parameters its invalid"
+msgstr "Some input parameters its invalid"
+
+#: neomaril_codex.training.NeomarilTrainingExperiment.run_training:30 of
+msgid ""
+"The return of the scoring function in the source file for Sync models or "
+"the execution class for Async models."
+msgstr ""
+"The return of the scoring function in the source file for Sync models or "
+"the execution class for Async models."
+
 #: ../../source/training.rst:26
 msgid "neomaril\\_codex.training.NeomarilTrainingClient"
 msgstr "neomaril\\_codex.training.NeomarilTrainingClient"
+
+#: neomaril_codex.training.NeomarilTrainingClient:1 of
+msgid "Bases: :py:class:`~neomaril_codex.base.BaseNeomarilClient`"
+msgstr "Bases: :py:class:`~neomaril_codex.base.BaseNeomarilClient`"
+
+#: neomaril_codex.training.NeomarilTrainingClient:1 of
+msgid "Class for client for acessing Neomaril and manage models"
+msgstr "Class for client for acessing Neomaril and manage models"
+
+#: neomaril_codex.training.NeomarilTrainingClient:17 of
+msgid ""
+"URL to Neomaril Server. Default value is "
+"https://neomaril.staging.datarisk.net, use it to test your deployment "
+"first before changing to production. You can also use the env variable "
+"NEOMARIL_URL to set this"
+msgstr ""
+"URL to Neomaril Server. Default value is "
+"https://neomaril.staging.datarisk.net, use it to test your deployment "
+"first before changing to production. You can also use the env variable "
+"NEOMARIL_URL to set this"
+
+#: neomaril_codex.training.NeomarilTrainingClient:22 of
+msgid "Server unavailable"
+msgstr "Server unavailable"
+
+#: neomaril_codex.training.NeomarilTrainingClient.create_training_experiment:1
+#: of
+msgid "Create a new training experiment on Neomaril."
+msgstr "Create a new training experiment on Neomaril."
+
+#: neomaril_codex.training.NeomarilTrainingClient.create_training_experiment:3
+#: of
+msgid "The name of the experiment, in less than 32 characters"
+msgstr "The name of the experiment, in less than 32 characters"
+
+#: neomaril_codex.training.NeomarilTrainingClient.create_training_experiment:5
+#: of
+msgid "The name of the scoring function inside the source file."
+msgstr "The name of the scoring function inside the source file."
+
+#: neomaril_codex.training.NeomarilTrainingClient.create_training_experiment:7
+#: of
+msgid "Group the model is inserted. Default to 'datarisk' (public group)"
+msgstr "Group the model is inserted. Default to 'datarisk' (public group)"
+
+#: neomaril_codex.training.NeomarilTrainingClient.create_training_experiment:11
+#: of
+msgid "Unknow internal server error"
+msgstr "Unknow internal server error"
+
+#: neomaril_codex.training.NeomarilTrainingClient.create_training_experiment:13
+#: neomaril_codex.training.NeomarilTrainingClient.get_training:11 of
+msgid ""
+"A NeomarilTrainingExperiment instance with the training hash from "
+"`training_id`"
+msgstr ""
+"A NeomarilTrainingExperiment instance with the training hash from "
+"`training_id`"
+
+#: neomaril_codex.training.NeomarilTrainingClient.get_training:1 of
+msgid "Acess a model using its id"
+msgstr "Acess a model using its id"
+
+#: neomaril_codex.training.NeomarilTrainingClient.get_training:3 of
+msgid "Training id (hash) that needs to be acessed"
+msgstr "Training id (hash) that needs to be acessed"
+
+#: neomaril_codex.training.NeomarilTrainingClient.get_training:5 of
+msgid "Group the model is inserted. Default is 'datarisk' (public group)"
+msgstr "Group the model is inserted. Default is 'datarisk' (public group)"
+
+#: neomaril_codex.training.NeomarilTrainingClient.get_training:8 of
+msgid "Model unavailable"
+msgstr "Model unavailable"
+
+#: neomaril_codex.training.NeomarilTrainingClient.get_training:9 of
+msgid "Unknown return from server"
+msgstr "Unknown return from server"
 

--- a/docs/source/neomaril_codex.rst
+++ b/docs/source/neomaril_codex.rst
@@ -26,13 +26,17 @@ Modules
 .. toctree::
    :maxdepth: 5
 
+   preprocessing
+
+.. toctree::
+   :maxdepth: 5
+
    pipeline
 
 .. toctree::
    :maxdepth: 5
 
    logging
-
 
 .. toctree::
    :maxdepth: 5

--- a/docs/source/preprocessing.rst
+++ b/docs/source/preprocessing.rst
@@ -1,0 +1,23 @@
+Preprocessing module
+============================
+
+
+Module with all classes and methods to manage the Machine Learning (ML) preprocessing scripts deployed at Neomaril.
+
+
+neomaril\_codex.preprocessing.NeomarilPreprocessing
+-----------------------------------
+
+.. autoclass:: neomaril_codex.preprocessing.NeomarilPreprocessing
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+neomaril\_codex.preprocessing.NeomarilPreprocessingClient
+-----------------------------------------
+
+.. autoclass:: neomaril_codex.preprocessing.NeomarilPreprocessingClient
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/preprocessing.rst
+++ b/docs/source/preprocessing.rst
@@ -2,7 +2,7 @@ Preprocessing module
 ============================
 
 
-Module with all classes and methods to manage the Machine Learning (ML) preprocessing scripts deployed at Neomaril.
+Module with all classes and methods to manage the Preprocessing scripts deployed at Neomaril.
 
 
 neomaril\_codex.preprocessing.NeomarilPreprocessing

--- a/docs/source/preprocessing.rst
+++ b/docs/source/preprocessing.rst
@@ -6,7 +6,7 @@ Module with all classes and methods to manage the Machine Learning (ML) preproce
 
 
 neomaril\_codex.preprocessing.NeomarilPreprocessing
------------------------------------
+---------------------------------------------------------
 
 .. autoclass:: neomaril_codex.preprocessing.NeomarilPreprocessing
    :members:
@@ -15,7 +15,7 @@ neomaril\_codex.preprocessing.NeomarilPreprocessing
 
 
 neomaril\_codex.preprocessing.NeomarilPreprocessingClient
------------------------------------------
+------------------------------------------------------------
 
 .. autoclass:: neomaril_codex.preprocessing.NeomarilPreprocessingClient
    :members:

--- a/notebooks/Preprocessing.ipynb
+++ b/notebooks/Preprocessing.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -10,6 +11,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -27,6 +29,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -53,6 +56,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -179,6 +183,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -304,6 +309,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -360,6 +366,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -384,6 +391,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -391,6 +399,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -414,6 +423,14 @@
    ],
    "source": [
     "model_client = NeomarilModelClient()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Sync Model"
    ]
   },
   {
@@ -444,6 +461,14 @@
     "sync_model = model_client.get_model(group='datarisk', model_id='M3aa182ff161478a97f4d3b2dc0e9b064d5a9e7330174daeb302e01586b9654c')\n",
     "\n",
     "sync_model.predict(data=sync_model.schema, preprocessing=sync_preprocessing)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Async Model"
    ]
   },
   {

--- a/src/neomaril_codex/pipeline.py
+++ b/src/neomaril_codex/pipeline.py
@@ -15,13 +15,13 @@ class NeomarilPipeline:
 
     Atributtes
     ----------
-	login : str
-		Login for authenticating with the client. You can also use the env variable NEOMARIL_USER to set this
-	password : str
-		Password for authenticating with the client. You can also use the env variable NEOMARIL_PASSWORD to set this
+    login : str
+        Login for authenticating with the client. You can also use the env variable NEOMARIL_USER to set this
+    password : str
+        Password for authenticating with the client. You can also use the env variable NEOMARIL_PASSWORD to set this
     group : str
         Group the model is inserted
-	url : str
+    url : str
         URL to Neomaril Server. Default value is https://neomaril.staging.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable NEOMARIL_URL to set this
     python_version : str
         Python version for the model environment. Avaliable versions are 3.7, 3.8, 3.9, 3.10. Defaults to '3.9'

--- a/src/neomaril_codex/pipeline.py
+++ b/src/neomaril_codex/pipeline.py
@@ -19,7 +19,7 @@ class NeomarilPipeline:
 		Login for authenticating with the client. You can also use the env variable NEOMARIL_USER to set this
 	password : str
 		Password for authenticating with the client. You can also use the env variable NEOMARIL_PASSWORD to set this
-    group: str
+    group : str
         Group the model is inserted
 	url : str
         URL to Neomaril Server. Default value is https://neomaril.staging.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable NEOMARIL_URL to set this

--- a/src/neomaril_codex/pipeline.py
+++ b/src/neomaril_codex/pipeline.py
@@ -22,7 +22,7 @@ class NeomarilPipeline:
     group: str
         Group the model is inserted
 	url : str
-		URL to Neomaril Server. Default value is https://neomaril.staging.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable NEOMARIL_URL to set this
+        URL to Neomaril Server. Default value is https://neomaril.staging.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable NEOMARIL_URL to set this
     python_version : str
         Python version for the model environment. Avaliable versions are 3.7, 3.8, 3.9, 3.10. Defaults to '3.9'
         

--- a/src/neomaril_codex/preprocessing.py
+++ b/src/neomaril_codex/preprocessing.py
@@ -36,23 +36,11 @@ class NeomarilPreprocessing(BaseNeomaril):
         from neomaril_codex.preprocessing import NeomarilPreprocessingClient
         from neomaril_codex.model import NeomarilModelClient
 
-        client = NeomarilPreprocessingClient()
-        PATH = './samples/syncPreprocessing/'
+        client = NeomarilPreprocessingClient('123456')
+        
+        client.search_preprocessing()
 
-        sync_preprocessing = client.create('Teste preprocessing Sync', # model_name
-                            'process', # name of the scoring function
-                            PATH+'app.py', # Path of the source file
-                            PATH+'requirements.txt', # Path of the requirements file, 
-                            schema=PATH+'schema.json', # Path of the schema file, but it could be a dict (only required for Sync models)
-                            python_version='3.9', # Can be 3.7 to 3.10
-                            operation="Sync", # Can be Sync or Async
-                            group='datarisk' # Model group (create one using the client)
-                            )
-
-        sync_preprocessing.set_token('TOKEN')
-
-        result = sync_preprocessing.run({'variable' : 100})
-        result
+        preprocessing = client.get_preprocessing(preprocessing_id='S72110d87c2a4341a7ef0a0cb35e483699db1df6c5d2450f92573c093c65b062', group='ex_group')
     
     """
 

--- a/src/neomaril_codex/preprocessing.py
+++ b/src/neomaril_codex/preprocessing.py
@@ -11,6 +11,50 @@ from neomaril_codex.__utils import *
 from neomaril_codex.exceptions import *
 
 class NeomarilPreprocessing(BaseNeomaril):
+    """
+    Class to manage Preprocessing scripts deployed inside Neomaril
+
+    Attributes
+    ----------
+	login : str
+		Login for authenticating with the client. You can also use the env variable NEOMARIL_USER to set this
+	password : str
+		Password for authenticating with the client. You can also use the env variable NEOMARIL_PASSWORD to set this
+    preprocessing_id : str
+        Preprocessing script id (hash) from the script you want to access
+    group : str
+        Group the model is inserted. Default is 'datarisk' (public group)
+    base_url : str
+        URL to Neomaril Server. Default value is https://neomaril.staging.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable NEOMARIL_URL to set this
+
+    Example
+    --------
+    Getting a model, testint its healthy and putting it to run the prediction
+
+    .. code-block:: python
+
+        from neomaril_codex.preprocessing import NeomarilPreprocessingClient
+        from neomaril_codex.model import NeomarilModelClient
+
+        client = NeomarilPreprocessingClient()
+        PATH = './samples/syncPreprocessing/'
+
+        sync_preprocessing = client.create('Teste preprocessing Sync', # model_name
+                            'process', # name of the scoring function
+                            PATH+'app.py', # Path of the source file
+                            PATH+'requirements.txt', # Path of the requirements file, 
+                            schema=PATH+'schema.json', # Path of the schema file, but it could be a dict (only required for Sync models)
+                            python_version='3.9', # Can be 3.7 to 3.10
+                            operation="Sync", # Can be Sync or Async
+                            group='datarisk' # Model group (create one using the client)
+                            )
+
+        sync_preprocessing.set_token('TOKEN')
+
+        result = sync_preprocessing.run({'variable' : 100})
+        result
+    
+    """
 
     def __init__(self, preprocessing_id:str, login:Optional[str]=None, password:Optional[str]=None, group:str="datarisk", 
                  group_token:Optional[str]=None, url:str='https://neomaril.staging.datarisk.net/') -> None:

--- a/src/neomaril_codex/preprocessing.py
+++ b/src/neomaril_codex/preprocessing.py
@@ -319,7 +319,7 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
         from neomaril_codex.preprocessing import NeomarilPreprocessingClient
         from neomaril_codex.model import NeomarilModelClient
 
-        client = NeomarilPreprocessingClient()
+        client = NeomarilPreprocessingClient('123456')
         PATH = './samples/syncPreprocessing/'
 
         sync_preprocessing = client.create('Teste preprocessing Sync', # model_name
@@ -346,7 +346,7 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
         from neomaril_codex.preprocessing import NeomarilPreprocessingClient
         from neomaril_codex.model import NeomarilModelClient
         
-        client = NeomarilPreprocessingClient()
+        client = NeomarilPreprocessingClient('123456')
         PATH = './samples/asyncPreprocessing/'
 
         async_preprocessing = client.create('Teste preprocessing Async', # model_name
@@ -367,6 +367,41 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
 
         execution.get_status()
 
+        execution.wait_ready()
+
+        execution.download_result()
+
+    Example 3: Using preprocessing with a Synchronous model
+    
+    .. code-block:: python
+        
+        from neomaril_codex.preprocessing import NeomarilPreprocessingClient
+        from neomaril_codex.model import NeomarilModelClient
+
+        # the sync preprocess script configuration presented before
+        # ...
+
+        model_client = NeomarilModelClient('123456')
+
+        sync_model = model_client.get_model(group='datarisk', model_id='M3aa182ff161478a97f4d3b2dc0e9b064d5a9e7330174daeb302e01586b9654c')
+
+        sync_model.predict(data=sync_model.schema, preprocessing=sync_preprocessing)
+
+    Example 4: Using preprocessing with an Asynchronous model
+    
+    .. code-block:: python
+        
+        from neomaril_codex.preprocessing import NeomarilPreprocessingClient
+        from neomaril_codex.model import NeomarilModelClient
+
+        # the async preprocess script configuration presented before
+        # ...
+
+        async_model = model_client.get_model(group='datarisk', model_id='Maa3449c7f474567b6556614a12039d8bfdad0117fec47b2a4e03fcca90b7e7c')
+
+        PATH = './samples/asyncModel/'
+
+        execution = async_model.predict(PATH+'input.csv', preprocessing=async_preprocessing)
         execution.wait_ready()
 
         execution.download_result()

--- a/src/neomaril_codex/preprocessing.py
+++ b/src/neomaril_codex/preprocessing.py
@@ -303,7 +303,86 @@ class NeomarilPreprocessing(BaseNeomaril):
             raise PreprocessingError(response.text)
         
 class NeomarilPreprocessingClient(BaseNeomarilClient):
+    """
+    Class for client to access Neomaril and manage Preprocessing scripts
 
+    Attributes
+    ----------
+	login : str
+		Login for authenticating with the client. You can also use the env variable NEOMARIL_USER to set this
+	password : str
+		Password for authenticating with the client. You can also use the env variable NEOMARIL_PASSWORD to set this
+	url : str
+		URL to Neomaril Server. Default value is https://neomaril.staging.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable NEOMARIL_URL to set this
+
+    Raises
+    ------
+    AuthenticationError
+        Unvalid credentials
+    ServerError
+        Server unavailable
+
+    Example
+    --------
+    Example 1: Creation and managing a Synchronous Preprocess script
+
+    .. code-block:: python
+        
+        from neomaril_codex.preprocessing import NeomarilPreprocessingClient
+        from neomaril_codex.model import NeomarilModelClient
+
+        client = NeomarilPreprocessingClient()
+        PATH = './samples/syncPreprocessing/'
+
+        sync_preprocessing = client.create('Teste preprocessing Sync', # model_name
+                            'process', # name of the scoring function
+                            PATH+'app.py', # Path of the source file
+                            PATH+'requirements.txt', # Path of the requirements file, 
+                            schema=PATH+'schema.json', # Path of the schema file, but it could be a dict (only required for Sync models)
+                            # env=PATH+'.env'  #  File for env variables (this will be encrypted in the server)
+                            # extra_files=[PATH+'utils.py'], # List with extra files paths that should be uploaded along (they will be all in the same folder)
+                            python_version='3.9', # Can be 3.7 to 3.10
+                            operation="Sync", # Can be Sync or Async
+                            group='datarisk' # Model group (create one using the client)
+                            )
+
+        sync_preprocessing.set_token('TOKEN')
+
+        result = sync_preprocessing.run({'variable' : 100})
+        result
+
+    Example 2: creation and deployment of an Asynchronous Preprocess script
+    
+    .. code-block:: python
+        
+        from neomaril_codex.preprocessing import NeomarilPreprocessingClient
+        from neomaril_codex.model import NeomarilModelClient
+        
+        client = NeomarilPreprocessingClient()
+        PATH = './samples/asyncPreprocessing/'
+
+        async_preprocessing = client.create('Teste preprocessing Async', # model_name
+                            'process', # name of the scoring function
+                            PATH+'app.py', # Path of the source file
+                            PATH+'requirements.txt', # Path of the requirements file, 
+                            # env=PATH+'.env',  #  File for env variables (this will be encrypted in the server)
+                            # extra_files=[PATH+'input.csv'], # List with extra files paths that should be uploaded along (they will be all in the same folder)
+                            python_version='3.9', # Can be 3.7 to 3.10
+                            operation="Async", # Can be Sync or Async
+                            group='datarisk', # Model group (create one using the client)
+                            input_type='csv'
+                            )
+
+        async_preprocessing.set_token('TOKEN')
+
+        execution = async_preprocessing.run(PATH+'input.csv')
+
+        execution.get_status()
+
+        execution.wait_ready()
+
+        execution.download_result()
+    """
     def __init__(self, login:Optional[str]=None, password:Optional[str]=None, url:str='https://neomaril.staging.datarisk.net/') -> None:
 
         load_dotenv()


### PR DESCRIPTION
## Description

With this PR, I'm: 

- [x] Updating the Codex documentation by finishing the "Monitoring" documentation on [deploying.rst](https://github.com/datarisk-io/mlops-neomaril-codex/blob/master/docs/source/deploying.rst);
- [x] Adding a new section to the [Preprocessing notebook](https://github.com/datarisk-io/mlops-neomaril-codex/blob/master/notebooks/Preprocessing.ipynb), basically extending what we have there;
- [x] Adding a new section like [this](https://github.com/datarisk-io/mlops-neomaril-codex/blob/master/docs/source/model.rst), but for the preprocessing module;
- [x] Adding missing docstrings on `preprocessing.py`;
- [x] Fix indentation on `pipeline.py`;
~- [ ] Add/update pt-br translation.~ TO BE SOLVED WITH ANOTHER PR.

To update the translation (reference [link](https://www.sphinx-doc.org/en/master/usage/advanced/intl.html)):

```bash
cd docs/

make gettext

sphinx-intl update -p build/gettext -l pt_BR
# finish the process by adding the translations to the generate .po files
```

## Related issues

- Close https://linear.app/datarisk/issue/NEODV-550/[request]-atualizar-documentacao-do-codex
- Related to https://github.com/datarisk-io/mlops-neomaril-codex/pull/25

## How to test it

```bash
# install dependencies
pip install pydata-sphinx-theme==0.12.0 sphinx==6.1.3 sphinx-intl==2.1.0 m2r2
pip install -r requirements.txt

# build the documentation pages locally
sphinx-build docs/source _build
sphinx-build docs/source -D language='pt_BR' _build/pt_BR

# open the built docs with chrome browser
google-chrome _build/index.html
```

Navigate through the documentation and assert that it's looking correct.