### PR TITLE
Solve target proportion key error

### DIFF
--- a/src/neomaril_codex/training.py
+++ b/src/neomaril_codex/training.py
@@ -248,10 +248,10 @@ class NeomarilTrainingLogger:
             params = {**params, **hyperparameters}
 
         if len(self.y_train.value_counts()) < 10:
-            target_proportion = (
-                self.y_train.value_counts() / len(self.y_train)
-            ).to_dict()
-
+            
+            target_proportion = self.y_train.value_counts() / len(self.y_train)
+            target_proportion = target_proportion.to_dict()
+            target_proportion = { str(k[0]) : v for k, v in target_proportion.items() }
             params['target_proportion'] = target_proportion
         else:
             params["target_distribution"] = {

--- a/src/neomaril_codex/training.py
+++ b/src/neomaril_codex/training.py
@@ -248,10 +248,9 @@ class NeomarilTrainingLogger:
             params = {**params, **hyperparameters}
 
         if len(self.y_train.value_counts()) < 10:
-            
             target_proportion = self.y_train.value_counts() / len(self.y_train)
             target_proportion = target_proportion.to_dict()
-            target_proportion = { str(k[0]) : v for k, v in target_proportion.items() }
+            target_proportion = [ { 'target' : k, 'proportion' : v  } for k, v in target_proportion.items() ]
             params['target_proportion'] = target_proportion
         else:
             params["target_distribution"] = {


### PR DESCRIPTION
## Description

Everytime when we send a external training in the external training process, we recive a error related to a key error because the target_proportion it's a pandas series and be transformed to a dict with to_dict, but in this transform, we recive a tuple as key, and it's not permited to export as a JSON a tuple as a key.