### PR TITLE
depreciate python 3.7

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "50dc27996f4edac69cb31d2c395863b0ccd06816711cce083393b190725fe83d"
+            "sha256": "eaba094f623e6ea58c4286b4e93f7d6438e2ee6f4e3db15f242d1ac13262bb33"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -386,11 +386,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d",
-                "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
+                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
+                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==2.2.1"
+            "version": "==2.2.2"
         }
     },
     "develop": {

--- a/docs/source/deploying.rst
+++ b/docs/source/deploying.rst
@@ -139,7 +139,7 @@ With all files ready we can deploy the model in two ways.
         schema=PATH+'schema.json', # Path of the schema file, but it could be a dict (only required for Sync models)
         # env=PATH+'.env'  #  File for env variables (this will be encrypted in the server)
         # extra_files=[PATH+'utils.py'], # List with extra files paths that should be uploaded along (they will be all in the same folder)
-        python_version='3.9', # Can be 3.7 to 3.10
+        python_version='3.9', # Can be 3.8 to 3.10
         operation="Sync", # Can be Sync or Async
         group='datarisk' # Model group (create one using the client)
     )

--- a/docs/source/locale/pt_BR/LC_MESSAGES/model.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/model.po
@@ -519,11 +519,11 @@ msgstr ""
 
 #: neomaril_codex.model.NeomarilModelClient.create_model:21 of
 msgid ""
-"Python version for the model environment. Avaliable versions are 3.7, "
-"3.8, 3.9, 3.10. Defaults to '3.8'"
+"Python version for the model environment. Avaliable versions are 3.8, "
+"3.9, 3.10. Defaults to '3.8'"
 msgstr ""
-"Python version for the model environment. Avaliable versions are 3.7, "
-"3.8, 3.9, 3.10. Defaults to '3.8'"
+"Python version for the model environment. Avaliable versions are 3.8, "
+"3.9, 3.10. Defaults to '3.8'"
 
 #: neomaril_codex.model.NeomarilModelClient.create_model:23 of
 msgid ""

--- a/docs/source/locale/pt_BR/LC_MESSAGES/pipeline.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/pipeline.po
@@ -106,11 +106,11 @@ msgstr "python_version"
 
 #: neomaril_codex.pipeline.NeomarilPipeline:14 of
 msgid ""
-"Python version for the model environment. Avaliable versions are 3.7, "
-"3.8, 3.9, 3.10. Defaults to '3.9'"
+"Python version for the model environment. Avaliable versions are 3.8, "
+"3.9 and 3.10. Defaults to '3.9'"
 msgstr ""
-"Python version for the model environment. Avaliable versions are 3.7, "
-"3.8, 3.9, 3.10. Defaults to '3.9'"
+"Python version for the model environment. Avaliable versions are 3.8, "
+"3.9 and 3.10. Defaults to '3.9'"
 
 #: neomaril_codex.pipeline.NeomarilPipeline:17
 #: neomaril_codex.pipeline.NeomarilPipeline.from_config_file:12

--- a/docs/source/locale/pt_BR/LC_MESSAGES/preprocessing.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/preprocessing.po
@@ -396,10 +396,10 @@ msgstr ""
 #: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:19 of
 msgid ""
 "Python version for the pre processing environment. Avaliable versions are"
-" 3.7, 3.8, 3.9, 3.10. Defaults to '3.8'"
+" 3.8, 3.9, 3.10. Defaults to '3.8'"
 msgstr ""
 "Python version for the pre processing environment. Avaliable versions are"
-" 3.7, 3.8, 3.9, 3.10. Defaults to '3.8'"
+" 3.8, 3.9, 3.10. Defaults to '3.8'"
 
 #: neomaril_codex.preprocessing.NeomarilPreprocessingClient.create:21 of
 msgid ""

--- a/docs/source/locale/pt_BR/LC_MESSAGES/training.po
+++ b/docs/source/locale/pt_BR/LC_MESSAGES/training.po
@@ -360,11 +360,11 @@ msgstr "Description of the experiment"
 
 #: neomaril_codex.training.NeomarilTrainingExperiment.run_training:13 of
 msgid ""
-"Python version for the model environment. Avaliable versions are 3.7, "
-"3.8, 3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom"
+"Python version for the model environment. Avaliable versions are 3.8, "
+"3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom"
 msgstr ""
-"Python version for the model environment. Avaliable versions are 3.7, "
-"3.8, 3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom"
+"Python version for the model environment. Avaliable versions are 3.8, "
+"3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom"
 
 #: neomaril_codex.training.NeomarilTrainingExperiment.run_training:15 of
 msgid ""

--- a/docs/source/training_guide.rst
+++ b/docs/source/training_guide.rst
@@ -116,7 +116,7 @@ Then we can call the :py:meth:`neomaril_codex.training.NeomarilTrainingExperimen
         #env=PATH+'.env'  #  File for env variables (this will be encrypted in the server)
         #extra_files=[PATH+'utils.py'], # List with extra files paths that should be uploaded along (they will be all in the same folder)
         training_reference='train_model', # The name of the entrypoint function that is going to be called inside the source file 
-        python_version='3.9', # Can be 3.7 to 3.10
+        python_version='3.9', # Can be 3.8 to 3.10
         wait_complete=True
     )
 

--- a/notebooks/Model.ipynb
+++ b/notebooks/Model.ipynb
@@ -112,7 +112,7 @@
     "    schema=PATH+'schema.json', # Path of the schema file, but it could be a dict (only required for Sync models)\n",
     "    # env=PATH+'.env'  #  File for env variables (this will be encrypted in the server)\n",
     "    # extra_files=[PATH+'utils.py'], # List with extra files paths that should be uploaded along (they will be all in the same folder)\n",
-    "    python_version='3.9', # Can be 3.7 to 3.10\n",
+    "    python_version='3.9', # Can be 3.8 to 3.10\n",
     "    operation=\"Sync\", # Can be Sync or Async\n",
     "    group='groupname' # Model group (create one using the client)\n",
     ")"
@@ -361,7 +361,7 @@
     "    schema=PATH+'schema.csv', # Path of the schema file, but it could be a dict (only required for Sync models)\n",
     "    # env=PATH+'.env'  #  File for env variables (this will be encrypted in the server)\n",
     "    # extra_files=[PATH+'utils.py'], # List with extra files paths that should be uploaded along (they will be all in the same folder)\n",
-    "    python_version='3.9', # Can be 3.7 to 3.10\n",
+    "    python_version='3.9', # Can be 3.8 to 3.10\n",
     "    operation=\"Async\", # Can be Sync or Async\n",
     "    input_type='csv',# Can be json or csv or parquet\n",
     "    group='groupname' # Model group (create one using the client)\n",

--- a/notebooks/Preprocessing.ipynb
+++ b/notebooks/Preprocessing.ipynb
@@ -110,7 +110,7 @@
     "    schema=PATH+'schema.json', # Path of the schema file, but it could be a dict (only required for Sync models)\n",
     "    # env=PATH+'.env'  #  File for env variables (this will be encrypted in the server)\n",
     "    # extra_files=[PATH+'utils.py'], # List with extra files paths that should be uploaded along (they will be all in the same folder)\n",
-    "    python_version='3.9', # Can be 3.7 to 3.10\n",
+    "    python_version='3.9', # Can be 3.8 to 3.10\n",
     "    operation=\"Sync\", # Can be Sync or Async\n",
     "    group='groupname' # Model group (create one using the client)\n",
     ")"
@@ -239,7 +239,7 @@
     "    # env=PATH+'.env',  #  File for env variables (this will be encrypted in the server)\n",
     "    # extra_files=[PATH+'input.csv'], # List with extra files paths that should be uploaded along (they will be all in the same folder)\n",
     "    schema=PATH+'schema.csv',\n",
-    "    python_version='3.9', # Can be 3.7 to 3.10\n",
+    "    python_version='3.9', # Can be 3.8 to 3.10\n",
     "    operation=\"Async\", # Can be Sync or Async\n",
     "    group='groupname', # Model group (create one using the client)\n",
     "    input_type='csv',\n",

--- a/notebooks/Training.ipynb
+++ b/notebooks/Training.ipynb
@@ -161,7 +161,7 @@
     "    # extra_files=[PATH+'utils.py'], # List with extra files paths that should be uploaded along (they will be all in the same folder)\n",
     "    training_reference='train_model', # The name of the entrypoint function that is going to be called inside the source file \n",
     "    training_type='Custom',\n",
-    "    python_version='3.9', # Can be 3.7 to 3.10\n",
+    "    python_version='3.9', # Can be 3.8 to 3.10\n",
     "    wait_complete=True\n",
     ")"
    ]

--- a/src/neomaril_codex/model.py
+++ b/src/neomaril_codex/model.py
@@ -1295,7 +1295,7 @@ class NeomarilModelClient(BaseNeomarilClient):
         env : str, optional
             Flag that choose which environment (dev, staging, production) of Neomaril you are using. Default is True
         python_version : str, optional
-            Python version for the model environment. Avaliable versions are 3.7, 3.8, 3.9, 3.10. Defaults to '3.8'
+            Python version for the model environment. Avaliable versions are 3.8, 3.8, 3.9, 3.10. Defaults to '3.8'
         operation : str
             Defines wich kind operation is beeing executed (Sync or Async). Default value is Sync
         input_type : str
@@ -1460,7 +1460,7 @@ class NeomarilModelClient(BaseNeomarilClient):
         env : str, optional
             .env file to be used in your model enviroment. This will be encrypted in the server.
         python_version : str, optional
-            Python version for the model environment. Avaliable versions are 3.7, 3.8, 3.9, 3.10. Defaults to '3.8'
+            Python version for the model environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.8'
         operation : str
             Defines wich kind operation is beeing executed (Sync or Async). Default value is Sync
         input_type : str
@@ -1483,9 +1483,9 @@ class NeomarilModelClient(BaseNeomarilClient):
         >>> model = client.create_model('Model Example Sync', 'score',  './samples/syncModel/app.py', './samples/syncModel/'model.pkl', './samples/syncModel/requirements.txt','./samples/syncModel/schema.json', group=group, operation="Sync")
         """
 
-        if python_version not in ["3.7", "3.8", "3.9", "3.10"]:
+        if python_version not in ["3.8", "3.9", "3.10"]:
             raise InputError(
-                "Invalid python version. Avaliable versions are 3.7, 3.8, 3.9, 3.10"
+                "Invalid python version. Avaliable versions are 3.8, 3.9, 3.10"
             )
 
         if group:

--- a/src/neomaril_codex/pipeline.py
+++ b/src/neomaril_codex/pipeline.py
@@ -24,7 +24,7 @@ class NeomarilPipeline(BaseNeomaril):
     url : str
         URL to Neomaril Server. Default value is https://neomaril.staging.datarisk.net, use it to test your deployment first before changing to production. You can also use the env variable NEOMARIL_URL to set this
     python_version : str
-        Python version for the model environment. Avaliable versions are 3.7, 3.8, 3.9, 3.10. Defaults to '3.9'
+        Python version for the model environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.9'
         
     Example
     --------     

--- a/src/neomaril_codex/preprocessing.py
+++ b/src/neomaril_codex/preprocessing.py
@@ -381,7 +381,7 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
                             schema=PATH+'schema.json', # Path of the schema file, but it could be a dict (only required for Sync models)
                             # env=PATH+'.env'  #  File for env variables (this will be encrypted in the server)
                             # extra_files=[PATH+'utils.py'], # List with extra files paths that should be uploaded along (they will be all in the same folder)
-                            python_version='3.9', # Can be 3.7 to 3.10
+                            python_version='3.9', # Can be 3.8 to 3.10
                             operation="Sync", # Can be Sync or Async
                             group='datarisk' # Model group (create one using the client)
                             )
@@ -407,7 +407,7 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
                             PATH+'requirements.txt', # Path of the requirements file,
                             # env=PATH+'.env',  #  File for env variables (this will be encrypted in the server)
                             # extra_files=[PATH+'input.csv'], # List with extra files paths that should be uploaded along (they will be all in the same folder)
-                            python_version='3.9', # Can be 3.7 to 3.10
+                            python_version='3.9', # Can be 3.8 to 3.10
                             operation="Async", # Can be Sync or Async
                             group='datarisk', # Model group (create one using the client)
                             input_type='csv'
@@ -763,7 +763,7 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
         env : str, optional
             Flag that choose which environment (dev, staging, production) of Neomaril you are using. Default is True
         python_version : str, optional
-            Python version for the pre processing environment. Avaliable versions are 3.7, 3.8, 3.9, 3.10. Defaults to '3.8'
+            Python version for the pre processing environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.8'
         operation : str
             Defines wich kind operation is beeing executed (Sync or Async). Default value is Sync
         input_type : str
@@ -931,7 +931,7 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
         env : str, optional
             Flag that choose which environment (dev, staging, production) of Neomaril you are using. Default is True
         python_version : str, optional
-            Python version for the pre processing environment. Avaliable versions are 3.7, 3.8, 3.9, 3.10. Defaults to '3.8'
+            Python version for the pre processing environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.8'
         operation : str
             Defines wich kind operation is beeing executed (Sync or Async). Default value is Sync
         input_type : str
@@ -954,9 +954,9 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
         >>> preprocessing = client.create('Pre processing Example Sync', 'score',  './samples/syncPreprocessing/app.py', './samples/syncPreprocessing/'preprocessing.pkl', './samples/syncPreprocessing/requirements.txt','./samples/syncPreprocessing/schema.json', group=group, operation="Sync")
         """
 
-        if python_version not in ["3.7", "3.8", "3.9", "3.10"]:
+        if python_version not in ["3.8", "3.9", "3.10"]:
             raise InputError(
-                "Invalid python version. Avaliable versions are 3.7, 3.8, 3.9, 3.10"
+                "Invalid python version. Avaliable versions are 3.8, 3.9, 3.10"
             )
 
         if group:

--- a/src/neomaril_codex/training.py
+++ b/src/neomaril_codex/training.py
@@ -869,7 +869,7 @@ class NeomarilTrainingExperiment(BaseNeomaril):
         training_reference : str, optional
             The name of the training function inside the source file. Just used when training_type is Custom
         python_version : str
-            Python version for the model environment. Avaliable versions are 3.7, 3.8, 3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom
+            Python version for the model environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom
         conf_dict : Union[str, dict], optional
             Path to a JSON file with a the AutoML configuration. A dict can be send as well. Just used when training_type is AutoML
         source_file : str, optional
@@ -1122,7 +1122,7 @@ class NeomarilTrainingExperiment(BaseNeomaril):
         description : str, optional
             Description of the experiment
         python_version : str, optional
-            Python version for the model environment. Avaliable versions are 3.7, 3.8, 3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom
+            Python version for the model environment. Avaliable versions are 3.8, 3.9, 3.10. Defaults to '3.8'. Just used when training_type is Custom
         conf_dict : Union[str, dict]
             Path to a JSON file with a the AutoML configuration. A dict can be send as well. Just used when training_type is AutoML
         source_file : str, optional
@@ -1189,9 +1189,9 @@ class NeomarilTrainingExperiment(BaseNeomaril):
                 "Invalid data input. Run training requires a train_data or dataset"
             )
 
-        if python_version not in ["3.7", "3.8", "3.9", "3.10"]:
+        if python_version not in ["3.8", "3.9", "3.10"]:
             raise InputError(
-                "Invalid python version. Avaliable versions are 3.7, 3.8, 3.9, 3.10"
+                "Invalid python version. Avaliable versions are 3.8, 3.9, 3.10"
             )
 
         if training_type not in ["Custom", "AutoML", "External"]:


### PR DESCRIPTION
## Description

With this pr: 
* Deprecate python 3.7;

## How to test it

* Setup your environment;
* Test upload a custom and external training with python 3.7 version;
* Test upload a sync and async model with python 3.7 version;
* Test upload a pre-processing script with python 3.7 version.

All cases above must show an error

## Affected areas

- Worker
- Preprocessing
- Training
- Sync Model execution
- Async Model execution

## Related issues

* Closes: https://linear.app/datarisk/issue/NEODV-1254/[task]-depreciar-o-python-37-codex

### Also

- [x] Tag yourself as assignee.