### PR TITLE
Techdebt adicionar no codex uma checagem pra ver se o thash neodv 1285

### DIFF
--- a/notebooks/Training.ipynb
+++ b/notebooks/Training.ipynb
@@ -20,8 +20,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-27T12:28:38.913416Z",
+     "start_time": "2024-08-27T12:28:38.470234Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from neomaril_codex.training import NeomarilTrainingClient"
@@ -29,24 +34,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-27T13:20:58.562764Z",
+     "start_time": "2024-08-27T13:18:40.119319Z"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-04-22 17:29:44.013 | INFO     | neomaril_codex.base:__init__:20 - Loading .env\n",
-      "2024-04-22 17:29:45.606 | INFO     | neomaril_codex.base:__init__:31 - Successfully connected to Neomaril\n"
+      "2024-08-27 12:45:28.800 | INFO     | neomaril_codex.base:__init__:29 - Loading .env\n",
+      "2024-08-27 12:45:31.620 | INFO     | neomaril_codex.base:__init__:48 - Successfully connected to Neomaril\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "NeomarilTrainingClient(url=\"http://localhost:7070/api\", version=\"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlFnc0JWQ0I5WFc0V1YtSkVCVkJiZyJ9.eyJodHRwczovL25lb21hcmlsLmRhdGFyaXNrLm5ldC9uZW9tYXJpbC1ncm91cCI6ImRhdGFyaXNrIiwiaHR0cHM6Ly9uZW9tYXJpbC5kYXRhcmlzay5uZXQvZW1haWwiOiJndWlsaGVybWUuY2FyZG9zb0BkYXRhcmlzay5pbyIsImh0dHBzOi8vbmVvbWFyaWwuZGF0YXJpc2submV0L3RlbmFudCI6ImRhdGFyaXNrIiwiaHR0cHM6Ly9uZW9tYXJpbC5kYXRhcmlzay5uZXQvdXNlci1hY3RpdmUiOnRydWUsImlzcyI6Imh0dHBzOi8vZGV2LW1rM283bGF6eGxlMzBod3EudXMuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDY1YTE1NTA0ZDRiOGYwZDdiNDBlOGE0YiIsImF1ZCI6WyJodHRwczovL2Rldi1tazNvN2xhenhsZTMwaHdxLnVzLmF1dGgwLmNvbS9hcGkvdjIvIiwiaHR0cHM6Ly9kZXYtbWszbzdsYXp4bGUzMGh3cS51cy5hdXRoMC5jb20vdXNlcmluZm8iXSwiaWF0IjoxNzEzODE3Nzg1LCJleHAiOjE3MTM4Mjg1ODUsInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwgYWRkcmVzcyBwaG9uZSByZWFkOmN1cnJlbnRfdXNlciB1cGRhdGU6Y3VycmVudF91c2VyX21ldGFkYXRhIGRlbGV0ZTpjdXJyZW50X3VzZXJfbWV0YWRhdGEgY3JlYXRlOmN1cnJlbnRfdXNlcl9tZXRhZGF0YSBjcmVhdGU6Y3VycmVudF91c2VyX2RldmljZV9jcmVkZW50aWFscyBkZWxldGU6Y3VycmVudF91c2VyX2RldmljZV9jcmVkZW50aWFscyB1cGRhdGU6Y3VycmVudF91c2VyX2lkZW50aXRpZXMgb2ZmbGluZV9hY2Nlc3MiLCJndHkiOiJwYXNzd29yZCIsImF6cCI6ImtyQjZNbEd2ZDhHQUlDWXdYT3dJWm1OQzBZOVRhUEE3In0.KexkHwsAsDzvTQqxhM5y9ZbX8amkHN_FWCd3WommeBMcJygRmcO8zlH0LVQxWAv1wcPU6MLBusiIH9qmRYaQJ66WPbDSY8MLY5EtHeiE_6oLB3H88346BdCRM9SOaGQ4ns0p2L2B_-SV6KNwKCa9K0_R2UqwSqahH74_V0bm1h4pJcgiNYppv1BP-4t7JUFQvspG-fZIEgRfniv0YumlMfvtmd7rTUzVCQ6zsHBceee_s5j9iWizTZsHL-jM_vxLYw049z3S-MgRryJC3cx7AJYSkc9Apl16eBX1mfByPQQMdxy13c6vqIqC0GsFznejSnODwxCGRMuYKGySw31jIw\")"
+       "NeomarilTrainingClient(url=\"http://localhost:7070/api\", version=\"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlFnc0JWQ0I5WFc0V1YtSkVCVkJiZyJ9.eyJodHRwczovL25lb21hcmlsLmRhdGFyaXNrLm5ldC9uZW9tYXJpbC1ncm91cCI6ImRhdGFyaXNrIiwiaHR0cHM6Ly9uZW9tYXJpbC5kYXRhcmlzay5uZXQvZW1haWwiOiJuZW9tYXJpbC1jaUBkYXRhcmlzay5pbyIsImh0dHBzOi8vbmVvbWFyaWwuZGF0YXJpc2submV0L3RlbmFudCI6ImRhdGFyaXNrIiwiaHR0cHM6Ly9uZW9tYXJpbC5kYXRhcmlzay5uZXQvdGVuYW50LWFjdGl2ZSI6dHJ1ZSwiaHR0cHM6Ly9uZW9tYXJpbC5kYXRhcmlzay5uZXQvdXNlci1hY3RpdmUiOnRydWUsImh0dHBzOi8vbmVvbWFyaWwuZGF0YXJpc2submV0L3JvbGUiOiJtYXN0ZXIiLCJpc3MiOiJodHRwczovL2Rldi1tazNvN2xhenhsZTMwaHdxLnVzLmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHw2NTY0Y2M0NTlkYzAzODhlNDVlMDQzZTciLCJhdWQiOlsiaHR0cHM6Ly9kZXYtbWszbzdsYXp4bGUzMGh3cS51cy5hdXRoMC5jb20vYXBpL3YyLyIsImh0dHBzOi8vZGV2LW1rM283bGF6eGxlMzBod3EudXMuYXV0aDAuY29tL3VzZXJpbmZvIl0sImlhdCI6MTcyNDc3MzUzMSwiZXhwIjoxNzI0Nzg0MzMxLCJzY29wZSI6Im9wZW5pZCBwcm9maWxlIGVtYWlsIGFkZHJlc3MgcGhvbmUgcmVhZDpjdXJyZW50X3VzZXIgdXBkYXRlOmN1cnJlbnRfdXNlcl9tZXRhZGF0YSBkZWxldGU6Y3VycmVudF91c2VyX21ldGFkYXRhIGNyZWF0ZTpjdXJyZW50X3VzZXJfbWV0YWRhdGEgY3JlYXRlOmN1cnJlbnRfdXNlcl9kZXZpY2VfY3JlZGVudGlhbHMgZGVsZXRlOmN1cnJlbnRfdXNlcl9kZXZpY2VfY3JlZGVudGlhbHMgdXBkYXRlOmN1cnJlbnRfdXNlcl9pZGVudGl0aWVzIG9mZmxpbmVfYWNjZXNzIiwiZ3R5IjoicGFzc3dvcmQiLCJhenAiOiJrckI2TWxHdmQ4R0FJQ1l3WE93SVptTkMwWTlUYVBBNyJ9.AYZ-8b-eEJodTsIm-osuq69c9OQWishgXTr-9Q3HalRPL1hdVUKQ6eJhQJzC74kzYru5Akfu-zsDfvMk32MJmbLIX4TsszjywkTFDOU104ZINQU0Dq9fuBSjrxJfgU8MJK9Z-TQ4QMNHUPxoP3TEm2YB5Wgfx2K5Y4kEq3j6KbiSTeQkWI0x2PFCe52E2Bd_3FSwqxULv26U4YOgmaVGtsyYEj29bGPHfMc4yyobyxZ9Yv36EvPh0k8syoz-SF4PJ3O0B7N-nB_Sje7r3R91srnp6UQFrSbRIFTdw20uA9gYNXNaNNIZnJDsPJ7ls39IdhlqzvHvnVKxKLKkqF5dJQ\")"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -73,49 +83,53 @@
    "source": [
     "#### Custom training\n",
     "\n",
-    "With Custom training you have to create the training function."
+    "With Custom training, you have to create the training function. For you, as a data scientist, it's common to re-run the entire notebook, over and over. To avoid creating the same experiment repeatedly, the `force = False` parameter will disallow it. If you wish to create a new experiment with the same attributes, turn `force = True`.\n",
+    "\n",
+    "If you have two equal experiments and pass `force = False`, the first created experiment will be chosen."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-04-22 17:29:46.182 | INFO     | neomaril_codex.training:create_training_experiment:1335 - New Training 'Teste notebook Training custom' inserted.\n",
-      "2024-04-22 17:29:46.183 | INFO     | neomaril_codex.base:__init__:20 - Loading .env\n",
-      "2024-04-22 17:29:46.188 | INFO     | neomaril_codex.base:__init__:31 - Successfully connected to Neomaril\n"
+      "2024-08-27 13:02:29.484 | INFO     | neomaril_codex.training:create_training_experiment:1569 - Trying to load experiment...\n",
+      "2024-08-27 13:02:29.707 | INFO     | neomaril_codex.training:__get_repeated_thash:1473 - Found experiment with same attributes...\n",
+      "2024-08-27 13:02:29.709 | INFO     | neomaril_codex.base:__init__:29 - Loading .env\n",
+      "2024-08-27 13:02:29.716 | INFO     | neomaril_codex.base:__init__:48 - Successfully connected to Neomaril\n"
      ]
     }
    ],
    "source": [
     "# Creating a new training experiment\n",
     "training = client.create_training_experiment(\n",
-    "    experiment_name='Teste notebook Training custom', # Experiment name, this is how you find your model in MLFLow\n",
-    "    model_type='Classification', # Model type. Can be Classification, Regression or Unsupervised\n",
-    "    group='groupname' # This is the default group. Create a new one when using for a new project\n",
+    "    experiment_name='Teste notebook',   # Experiment name, this is how you find your model in MLFLow\n",
+    "    model_type='Classification',        # Model type. Can be Classification, Regression or Unsupervised\n",
+    "    group='groupname',                  # This is the default group. Create a new one when using for a new project,\n",
+    "    # force=True                        # Forces to create a new experiment with the same attributes\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "NeomarilTrainingExperiment(name=\"Teste notebook Training custom\", \n",
-       "                                                        group=\"groupname\", \n",
-       "                                                        training_id=\"T508b769c7ca49a4a5e60d96fab003cace7533032858439f9b584cc026be02e1\",\n",
+       "NeomarilTrainingExperiment(name=\"Teste notebook\", \n",
+       "                                                        group=\"datarisk\", \n",
+       "                                                        training_id=\"T2500ebc20a54e188b0fe9f0b5b4f2a9e699e9ef475b4075a760cdfb84ab5224\",\n",
        "                                                        model_type=Classification\n",
        "                                                        )"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/src/neomaril_codex/training.py
+++ b/src/neomaril_codex/training.py
@@ -1556,7 +1556,7 @@ class NeomarilTrainingClient(BaseNeomarilClient):
         return training_id
 
     def create_training_experiment(
-        self, *, experiment_name: str, model_type: str, group: str = "datarisk"
+        self, *, experiment_name: str, model_type: str, group: str = "datarisk", force: bool = False
     ) -> NeomarilTrainingExperiment:
         """
         Create a new training experiment on Neomaril.

--- a/src/neomaril_codex/training.py
+++ b/src/neomaril_codex/training.py
@@ -1598,7 +1598,7 @@ class NeomarilTrainingClient(BaseNeomarilClient):
                 .replace("-", "_")
             )
 
-            groups = groups = [g.get("Name") for g in self.list_groups()]
+            groups = [g.get("Name") for g in self.list_groups()]
 
             if group not in groups:
                 raise GroupError("Group dont exist. Create a group first.")

--- a/src/neomaril_codex/training.py
+++ b/src/neomaril_codex/training.py
@@ -1440,7 +1440,7 @@ class NeomarilTrainingClient(BaseNeomarilClient):
         """Look for a previous train experiment.
 
         Args:
-            experiment_name (str): name given to the training, should be not null, case sensitive, have between 3 and 32 characters, 
+            experiment_name (str): name given to the training, should be not null, case-sensitive, have between 3 and 32 characters,
                                    that could be alphanumeric including accentuation (for example: 'é', à', 'ç','ñ') and space, 
                                    without blank spaces and special characters
 
@@ -1452,10 +1452,10 @@ class NeomarilTrainingClient(BaseNeomarilClient):
             group (str): name of the group, previous created, where the training will be inserted
 
         Raises:
-            InputError: some part of the data is incorret
+            InputError: some part of the data is incorrect
             AuthenticationError: user has insufficient permissions
-            ServerError: server is not availabe
-            Exception: generated excepetion in case of the response to the request is different than 201
+            ServerError: server is not available
+            Exception: generated exception in case of the response to the request is different than 201
 
         Returns:
             str | None: THash if it is found, otherwise, None is returned
@@ -1498,10 +1498,10 @@ class NeomarilTrainingClient(BaseNeomarilClient):
 
     def __create(self, experiment_name: str, model_type: str, group: str) -> str:
         """Creates a train experiment. A train experiment can aggregate multiple training runs (also called executions). 
-        Each execution can eventually became a deployed model or not.
+        Each execution can eventually become a deployed model or not.
 
         Args:
-            experiment_name (str): name given to the training, should be not null, case sensitive, have between 3 and 32 characters, 
+            experiment_name (str): name given to the training, should be not null, case-sensitive, have between 3 and 32 characters,
                                    that could be alphanumeric including accentuation (for example: 'é', à', 'ç','ñ') and space, 
                                    without blank spaces and special characters
 
@@ -1513,10 +1513,10 @@ class NeomarilTrainingClient(BaseNeomarilClient):
             group (str): name of the group, previous created, where the training will be inserted
 
         Raises:
-            InputError: some part of the data is incorret
+            InputError: some part of the data is incorrect
             AuthenticationError: user has insufficient permissions
-            ServerError: server is not availabe
-            Exception: generated excepetion in case of the response to the request is different than 201
+            ServerError: server is not available
+            Exception: generated exception in case of the response to the request is different than 201
 
         Returns:
             str: training hash of the experiment

--- a/src/neomaril_codex/training.py
+++ b/src/neomaril_codex/training.py
@@ -1569,6 +1569,8 @@ class NeomarilTrainingClient(BaseNeomarilClient):
             The name of the scoring function inside the source file.
         group : str
             Group the model is inserted. Default to 'datarisk' (public group)
+        force: bool
+            Forces to create a new training with the same model_type, experiment_name, group
 
         Raises
         ------

--- a/src/neomaril_codex/training.py
+++ b/src/neomaril_codex/training.py
@@ -1436,6 +1436,125 @@ class NeomarilTrainingClient(BaseNeomarilClient):
             url=self.base_url,
         )
 
+    def __get_repeated_thash(self, model_type: str, experiment_name: str, group: str) -> str | None:
+        """Look for a previous train experiment.
+
+        Args:
+            experiment_name (str): name given to the training, should be not null, case sensitive, have between 3 and 32 characters, 
+                                   that could be alphanumeric including accentuation (for example: 'é', à', 'ç','ñ') and space, 
+                                   without blank spaces and special characters
+
+            model_type (str): type of the model being trained. It can be
+                                Classification: for ML algorithms related to classification (predicts discrete class labels) problems;
+                                Regression: the ones that will use regression (predict a continuous quantity) algorithms;
+                                Unsupervised: for training that will use ML algorithms without supervision.
+
+            group (str): name of the group, previous created, where the training will be inserted
+
+        Raises:
+            InputError: some part of the data is incorret
+            AuthenticationError: user has insufficient permissions
+            ServerError: server is not availabe
+            Exception: generated excepetion in case of the response to the request is different than 201
+
+        Returns:
+            str | None: THash if it is found, otherwise, None is returned
+        """
+        url = f"{self.base_url}/training/search"
+        response = requests.get(
+            url,
+            headers={
+                "Authorization": "Bearer "
+                + refresh_token(*self.credentials, self.base_url)
+            },
+        )
+
+        if response.status_code == 400:
+            logger.error(response.text)
+            raise InputError("Bad Input")
+
+        if response.status_code == 401:
+            logger.error(response.text)
+            raise AuthenticationError("Login not authorized")
+
+        if response.status_code >= 500:
+            logger.error(response.text)
+            raise ServerError("Server Error")
+
+        if response.status_code != 200:
+            logger.error(response.text)
+            raise Exception("Unexpected error!")
+
+        results = response.json().get("Results")
+        for result in results:
+            condition = (
+                    result["ExperimentName"] == experiment_name
+                    and result["GroupName"] == group
+                    and result["ModelType"] == model_type
+            )
+            if condition:
+                logger.info("Found experiment with same attributes...")
+                return result["TrainingHash"]
+
+    def __create(self, experiment_name: str, model_type: str, group: str) -> str:
+        """Creates a train experiment. A train experiment can aggregate multiple training runs (also called executions). 
+        Each execution can eventually became a deployed model or not.
+
+        Args:
+            experiment_name (str): name given to the training, should be not null, case sensitive, have between 3 and 32 characters, 
+                                   that could be alphanumeric including accentuation (for example: 'é', à', 'ç','ñ') and space, 
+                                   without blank spaces and special characters
+
+            model_type (str): type of the model being trained. It can be
+                                Classification: for ML algorithms related to classification (predicts discrete class labels) problems;
+                                Regression: the ones that will use regression (predict a continuous quantity) algorithms;
+                                Unsupervised: for training that will use ML algorithms without supervision.
+
+            group (str): name of the group, previous created, where the training will be inserted
+
+        Raises:
+            InputError: some part of the data is incorret
+            AuthenticationError: user has insufficient permissions
+            ServerError: server is not availabe
+            Exception: generated excepetion in case of the response to the request is different than 201
+
+        Returns:
+            str: training hash of the experiment
+        """
+        url = f"{self.base_url}/training/register/{group}"
+
+        data = {"experiment_name": experiment_name, "model_type": model_type}
+
+        response = requests.post(
+            url,
+            data=data,
+            headers={
+                "Authorization": "Bearer "
+                                 + refresh_token(*self.credentials, self.base_url)
+            },
+        )
+
+        if response.status_code == 400:
+            logger.error(response.text)
+            raise InputError("Bad Input")
+
+        if response.status_code == 401:
+            logger.error(response.text)
+            raise AuthenticationError("Login not authorized")
+
+        if response.status_code >= 500:
+            logger.error(response.text)
+            raise ServerError("Server Error")
+
+        if response.status_code != 201:
+            logger.error(response.text)
+            raise Exception("Unexpected error!")
+
+        response_data = response.json()
+        logger.info(response_data["Message"])
+        training_id = response_data["TrainingHash"]
+        return training_id
+
     def create_training_experiment(
         self, *, experiment_name: str, model_type: str, group: str = "datarisk"
     ) -> NeomarilTrainingExperiment:


### PR DESCRIPTION
## Description

With this pr: Data scientists were creating the same experiment over and over, for each run in their notebook. To avoid it:
* Try to find a THash with same parameters before create a new;
* Give to the user the option to forces the creation of a new experiment with same attributes

## Related issues

* Closes: https://linear.app/datarisk/issue/NEODV-1285/[techdebt]-adicionar-no-codex-uma-checagem-pra-ver-se-o-thash-ja

## How to test it

Setup up your environment

```bash
pip uninstall neomaril-codex
pip install pipenv
pipenv update --dev
pipenv shell
pipenv sync
```

There are 4 cases test cases:

| Test Name                                                                 | Force Parameter | Assertion                                                  |
|---------------------------------------------------------------------------|-----------------|------------------------------------------------------------|
| Create a new experiment that does not exist and is not forced to be created | False           | Creates a new experiment                                    |
| Create a new experiment that does not exist and is forced to be created   | True            | Creates a new experiment                                    |
| Create a new experiment that already exists and is not forced to be created | False           | Does not create a new experiment. Returns the hash of the first valid experiment |
| Create a new experiment that already exists and is forced to be created   | True            | Creates a new experiment                                    |
