### PR TITLE
Techdebt neomarilclient salva o token de login numa chave neodv 1274

### DIFF
--- a/src/neomaril_codex/__utils.py
+++ b/src/neomaril_codex/__utils.py
@@ -26,7 +26,22 @@ def parse_url(url):
     return url
 
 
-def try_login(login: str, password: str, base_url: str) -> bool:
+def try_login(login: str, password: str, base_url: str) -> str | Exception:
+    """Try to sign in Neomaril
+
+    Args:
+        login: User email
+        password: User password
+        base_url: URL that will handle the requests
+
+    Returns:
+        User login token
+
+    Raises:
+        AuthenticationError: Raises if the `login` or `password` are wrong
+        ServerError: Raises if the server is not running correctly
+        BaseException: Raises if the server status is something different from 200
+    """
     response = requests.get(f"{base_url}/health")
 
     server_status = response.status_code

--- a/src/neomaril_codex/__utils.py
+++ b/src/neomaril_codex/__utils.py
@@ -46,14 +46,17 @@ def try_login(login: str, password: str, base_url: str) -> str | Exception:
 
     server_status = response.status_code
 
-    if server_status == 200:
-        token = refresh_token(login, password, base_url)
-        return token
-    elif server_status == 401:
-        raise AuthenticationError('Invalid credentials.')
+    if server_status == 401:
+        raise AuthenticationError('Email or password invalid.')
 
-    elif server_status >= 500:
+    if server_status >= 500:
         raise ServerError("Neomaril server unavailable at the moment.")
+
+    if server_status != 200:
+        raise Exception(f"Unexpected error! {response.text}")
+
+    token = refresh_token(login, password, base_url)
+    return token
 
 
 @ttl_cache

--- a/src/neomaril_codex/__utils.py
+++ b/src/neomaril_codex/__utils.py
@@ -26,7 +26,7 @@ def parse_url(url):
     return url
 
 
-def try_login(login: str, password: str, base_url: str) -> str | Exception:
+def try_login(login: str, password: str, base_url: str) -> tuple[str, str] | Exception:
     """Try to sign in Neomaril
 
     Args:
@@ -56,7 +56,8 @@ def try_login(login: str, password: str, base_url: str) -> str | Exception:
         raise Exception(f"Unexpected error! {response.text}")
 
     token = refresh_token(login, password, base_url)
-    return token
+    version = response.json().get("Version")
+    return token, version
 
 
 @ttl_cache

--- a/src/neomaril_codex/base.py
+++ b/src/neomaril_codex/base.py
@@ -32,7 +32,7 @@ class BaseNeomaril:
             login if login else os.getenv("NEOMARIL_USER"),
             password if password else os.getenv("NEOMARIL_PASSWORD"),
         )
-        self.base_url = os.getenv("NEOMARIL_URL") if os.getenv("NEOMARIL_URL") else url
+        self.base_url = url if url else os.getenv("NEOMARIL_URL")
         self.base_url = parse_url(self.base_url)
 
         if self.base_url == "https://neomaril.staging.datarisk.net/":
@@ -40,7 +40,7 @@ class BaseNeomaril:
                 "You are using the test enviroment that will have the data cleaned from time to time. If your model is ready to use change the enviroment to Production"
             )
 
-        self.client_version = try_login(
+        self.user_token = try_login(
             self.credentials[0],
             self.credentials[1],
             self.base_url,

--- a/src/neomaril_codex/base.py
+++ b/src/neomaril_codex/base.py
@@ -40,7 +40,7 @@ class BaseNeomaril:
                 "You are using the test enviroment that will have the data cleaned from time to time. If your model is ready to use change the enviroment to Production"
             )
 
-        self.user_token = try_login(
+        self.user_token, self.version = try_login(
             self.credentials[0],
             self.credentials[1],
             self.base_url,

--- a/src/neomaril_codex/model.py
+++ b/src/neomaril_codex/model.py
@@ -1060,10 +1060,10 @@ class NeomarilModelClient(BaseNeomarilClient):
     """
 
     def __repr__(self) -> str:
-        return f'NeomarilModelClient(url="{self.base_url}", version="{self.client_version}")'
+        return f'NeomarilModelClient(url="{self.base_url}", Token="{self.user_token}")'
 
     def __str__(self):
-        return f"NEOMARIL {self.base_url} Model client:{self.client_version}"
+        return f"NEOMARIL {self.base_url} Model client:{self.user_token}"
 
     def __get_model_status(self, model_id: str, group: str) -> dict:
         """

--- a/src/neomaril_codex/model.py
+++ b/src/neomaril_codex/model.py
@@ -1060,7 +1060,7 @@ class NeomarilModelClient(BaseNeomarilClient):
     """
 
     def __repr__(self) -> str:
-        return f'NeomarilModelClient(url="{self.base_url}", Token="{self.user_token}")'
+        return f'API version {self.version} - NeomarilModelClient(url="{self.base_url}", Token="{self.user_token}")'
 
     def __str__(self):
         return f"NEOMARIL {self.base_url} Model client:{self.user_token}"

--- a/src/neomaril_codex/training.py
+++ b/src/neomaril_codex/training.py
@@ -1393,7 +1393,7 @@ class NeomarilTrainingClient(BaseNeomarilClient):
     """
 
     def __repr__(self) -> str:
-        return f'NeomarilTrainingClient(url="{self.base_url}", Token="{self.user_token}")'
+        return f'API version {self.version} - NeomarilTrainingClient(url="{self.base_url}", Token="{self.user_token}")'
 
     def __str__(self):
         return f"NEOMARIL {self.base_url} Training client:{self.user_token}"

--- a/src/neomaril_codex/training.py
+++ b/src/neomaril_codex/training.py
@@ -1393,10 +1393,10 @@ class NeomarilTrainingClient(BaseNeomarilClient):
     """
 
     def __repr__(self) -> str:
-        return f'NeomarilTrainingClient(url="{self.base_url}", version="{self.client_version}")'
+        return f'NeomarilTrainingClient(url="{self.base_url}", Token="{self.user_token}")'
 
     def __str__(self):
-        return f"NEOMARIL {self.base_url} Training client:{self.client_version}"
+        return f"NEOMARIL {self.base_url} Training client:{self.user_token}"
 
     def get_training(
         self, *, training_id: str, group: str = "datarisk"


### PR DESCRIPTION
## Description

With this pr:
* Improve message when instantiate a client;
* Improve some parts of the code.

## Related issues

* Closed: https://linear.app/datarisk/issue/NEODV-1274/[techdebt]-neomarilclient-salva-o-token-de-login-numa-chave-version

## How to test it

Setup up your environment

```bash
pip uninstall neomaril-codex
pip install pipenv
pipenv update --dev
pipenv shell
pipenv sync
```

* Import one client (training, model, e.g);
* Instantiate that;
* Check the log