### PR TITLE
Techdebt adicionar mais mensagens de erro no codex neodv 1212

### DIFF
--- a/src/neomaril_codex/__model_states.py
+++ b/src/neomaril_codex/__model_states.py
@@ -4,29 +4,38 @@ to 'state.py' or something similar. The purpose will be modeling the possible st
 application
 """
 
-from enum import Enum, auto
+from enum import Enum
 
 
-class ModelState(Enum):
+class ModelState(str, Enum):
     """
-    Possible states of a mode
+    States of a model
     """
 
-    Ready = auto()
-    Building = auto()
-    Recovering = auto()
-    FailedRecovery = auto()
-    Failed = auto()
-    Deployed = auto()
-    Disabled = auto()
-    DisabledRecovery = auto()
-    DisabledFailed = auto()
-    Deleted = auto()
+    Ready = "Ready"
+    Building = "Building"
+    Recovering = "Recovering"
+    FailedRecovery = "FailedRecovery"
+    Failed = "Failed"
+    Deployed = "Deployed"
+    Disabled = "Disabled"
+    DisabledRecovery = "DisabledRecovery"
+    DisabledFailed = "DisabledFailed"
+    Deleted = "Deleted"
 
-    def __eq__(self, other):
-        if isinstance(other, str):
-            return str(self.name) == other
-        return super().__eq__(other)
+    def __str__(self):
+        return self.name
+
+
+class ModelExecutionState(str, Enum):
+    """
+    State of a model execution
+    """
+
+    Requested = "Requested"
+    Running = "Running"
+    Succeeded = "Succeeded"
+    Failed = "Failed"
 
     def __str__(self):
         return self.name

--- a/src/neomaril_codex/base.py
+++ b/src/neomaril_codex/base.py
@@ -30,7 +30,6 @@ class BaseNeomaril:
         password: Optional[str] = None,
         url: Optional[str] = None,
     ) -> None:
-
         load_dotenv()
         logger.info("Loading .env")
 
@@ -58,7 +57,7 @@ class BaseNeomaril:
             self.credentials[1],
             self.base_url,
         )
-        logger.info(f"Successfully connected to Neomaril")
+        logger.info("Successfully connected to Neomaril")
 
     def _logs(
         self,
@@ -408,7 +407,9 @@ class NeomarilExecution(BaseNeomaril):
                 logger.error(response.text)
                 raise AuthenticationError("Login not authorized")
             elif response.status_code == 404:
-                logger.error(f'Unable to retrieve execution "{exec_id}"\n{response.text}')
+                logger.error(
+                    f'Unable to retrieve execution "{exec_id}"\n{response.text}'
+                )
                 raise ModelError(f'Execution "{exec_id}" not found.')
             elif response.status_code >= 500:
                 logger.error(response.text)

--- a/src/neomaril_codex/base.py
+++ b/src/neomaril_codex/base.py
@@ -371,7 +371,7 @@ class NeomarilExecution(BaseNeomaril):
 
         self.exec_type = exec_type
         self.exec_id = exec_id
-        self.status = "Requested"
+        self.status = ModelExecutionState.Requested
         self.group = group
         self.__token = group_token if group_token else os.getenv("NEOMARIL_GROUP_TOKEN")
 
@@ -391,7 +391,7 @@ class NeomarilExecution(BaseNeomaril):
 
             self.execution_data = {}
 
-            self.status = "Running"
+            self.status = ModelExecutionState.Running
 
         else:
             url = f"{self.base_url}/{self.__url_path.replace('/async', '')}/describe/{group}/{parent_id}/{exec_id}"
@@ -417,7 +417,7 @@ class NeomarilExecution(BaseNeomaril):
 
             self.execution_data = response.json()["Description"]
 
-            self.status = self.execution_data["ExecutionState"]
+            self.status = ModelExecutionState[self.execution_data["ExecutionState"]]
 
     def __repr__(self) -> str:
         return f"""Neomaril{self.exec_type}Execution(exec_id="{self.exec_id}", status="{self.status}")"""
@@ -451,7 +451,7 @@ class NeomarilExecution(BaseNeomaril):
 
         result = response.json()
 
-        self.status = result["Status"]
+        self.status = ModelExecutionState[result["Status"]]
         self.execution_data["ExecutionState"] = result["Status"]
 
         return result
@@ -465,13 +465,18 @@ class NeomarilExecution(BaseNeomaril):
         >>> model.wait_ready()
         """
 
-        self.status = self.get_status()["Status"]
-        while self.status in ["Requested", "Running"]:
+        self.status = ModelExecutionState[self.get_status()["Status"]]
+        while self.status in [
+            ModelExecutionState.Requested,
+            ModelExecutionState.Running,
+        ]:
             sleep(30)
-            self.status = self.get_status()["Status"]
-        if self.status == "Failed":
+            self.status = ModelExecutionState[self.get_status()["Status"]]
+        if self.status == ModelExecutionState.Failed:
             logger.error("Execution failed! Please check the logs")
-            raise ExecutionError("Execution failed") # TODO: how to improve this message?
+            raise ExecutionError(
+                "Execution failed"
+            )  # TODO: how to improve this message?
         logger.info("Execution completed successfully")
 
     def download_result(
@@ -497,15 +502,15 @@ class NeomarilExecution(BaseNeomaril):
         dict
             Returns the path for the result file.
         """
-        if self.status in ["Running", "Requested"]:
-            self.status = self.get_status()["Status"]
+        if self.status in [ModelExecutionState.Running, ModelExecutionState.Requested]:
+            self.status = ModelExecutionState[self.get_status()["Status"]]
 
         if self.exec_type in ["AsyncModel", "AsyncPreprocessing"]:
             token = self.__token
         elif self.exec_type == "Training":
             token = refresh_token(*self.credentials, self.base_url)
 
-        if self.status == "Succeeded":
+        if self.status == ModelExecutionState.Succeeded:
             url = (
                 f"{self.base_url}/{self.__url_path}/result/{self.group}/{self.exec_id}"
             )
@@ -521,7 +526,7 @@ class NeomarilExecution(BaseNeomaril):
                 f.write(response.content)
 
             logger.info(f"Output saved in {path+filename}")
-        elif self.status == "Failed":
+        elif self.status == ModelExecutionState.Failed:
             raise ExecutionError("Execution failed")
         else:
             logger.info(f"Execution not ready. Status is {self.status}")

--- a/src/neomaril_codex/base.py
+++ b/src/neomaril_codex/base.py
@@ -7,9 +7,9 @@ import requests
 from dotenv import load_dotenv
 from loguru import logger
 
-from neomaril_codex.__utils import *
-from neomaril_codex.exceptions import *
-
+from neomaril_codex.__utils import refresh_token, parse_url, try_login
+from neomaril_codex.exceptions import ExecutionError, InputError, AuthenticationError, ModelError, ServerError
+from neomaril_codex.__model_states import ModelExecutionState
 
 class BaseNeomaril:
     """

--- a/src/neomaril_codex/base.py
+++ b/src/neomaril_codex/base.py
@@ -7,9 +7,16 @@ import requests
 from dotenv import load_dotenv
 from loguru import logger
 
-from neomaril_codex.__utils import refresh_token, parse_url, try_login
-from neomaril_codex.exceptions import ExecutionError, InputError, AuthenticationError, ModelError, ServerError
 from neomaril_codex.__model_states import ModelExecutionState
+from neomaril_codex.__utils import parse_url, refresh_token, try_login
+from neomaril_codex.exceptions import (
+    AuthenticationError,
+    ExecutionError,
+    InputError,
+    ModelError,
+    ServerError,
+)
+
 
 class BaseNeomaril:
     """

--- a/src/neomaril_codex/base.py
+++ b/src/neomaril_codex/base.py
@@ -448,7 +448,7 @@ class NeomarilExecution(BaseNeomaril):
 
         return result
 
-    def wait_ready(self):
+    def wait_ready(self) -> None:
         """
         Waits the execution until is no longer running
 
@@ -456,11 +456,15 @@ class NeomarilExecution(BaseNeomaril):
         -------
         >>> model.wait_ready()
         """
-        if self.status in ["Requested", "Running"]:
+
+        self.status = self.get_status()["Status"]
+        while self.status in ["Requested", "Running"]:
+            sleep(30)
             self.status = self.get_status()["Status"]
-            while self.status == "Running":
-                sleep(30)
-                self.status = self.get_status()["Status"]
+        if self.status == "Failed":
+            logger.error("Execution failed! Please check the logs")
+            raise ExecutionError("Execution failed") # TODO: how to improve this message?
+        logger.info("Execution completed successfully")
 
     def download_result(
         self, *, path: Optional[str] = "./", filename: Optional[str] = "output.zip"

--- a/src/neomaril_codex/base.py
+++ b/src/neomaril_codex/base.py
@@ -381,7 +381,7 @@ class NeomarilExecution(BaseNeomaril):
             )
 
         if exec_type == "AsyncPreprocessing":
-            # CHANGEME when add describe execution for preprocessing
+            # TODO: CHANGEME when add describe execution for preprocessing
 
             self.execution_data = {}
 

--- a/src/neomaril_codex/model.py
+++ b/src/neomaril_codex/model.py
@@ -558,12 +558,7 @@ class NeomarilModel(BaseNeomaril):
                         response = run.get_status()
                         status = response["Status"]
                         if wait_complete:
-                            print("Waiting the training run.", end="")
-                            while status in ["Running", "Requested"]:
-                                sleep(30)
-                                print(".", end="", flush=True)
-                                response = run.get_status()
-                                status = response["Status"]
+                            run.wait_ready()
                         if status == "Failed":
                             logger.error(response["Message"])
                             raise ExecutionError("Training execution failed")


### PR DESCRIPTION
## Description

With this pr:
* Raise exception if the model fails during `wait_ready()`;
* Improve error messages;
* Refactor parts of code.

## Related issues

* Closed: https://linear.app/datarisk/issue/NEODV-1212/[techdebt]-adicionar-mais-mensagens-de-erro-no-codex

## How to test it

Setup your environment

```bash
pip uninstall neomaril-codex
pip install pipenv
pipenv update --dev
pipenv shell
pipenv sync
```

Follow the steps:
1. Create a `NeomarilModelClient`
2. Create a new async model
3. Predict data and wait it be ready
4. See the error