### PR TITLE
feat: add custom header for codex request

### DIFF
--- a/src/neomaril_codex/base.py
+++ b/src/neomaril_codex/base.py
@@ -182,7 +182,14 @@ class BaseNeomarilClient(BaseNeomaril):
 
         token = refresh_token(*self.credentials, self.base_url)
 
-        response = requests.get(url, headers={"Authorization": "Bearer " + token})
+        response = requests.get(
+            url,
+            headers={
+                "Authorization": "Bearer " + token,
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.list_groups.__qualname__,
+            },
+        )
 
         if response.status_code == 200:
             results = response.json()["Results"]
@@ -231,7 +238,13 @@ class BaseNeomarilClient(BaseNeomaril):
         token = refresh_token(*self.credentials, self.base_url)
 
         response = requests.post(
-            url, data=data, headers={"Authorization": "Bearer " + token}
+            url,
+            data=data,
+            headers={
+                "Authorization": "Bearer " + token,
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.create_group.__qualname__,
+            },
         )
 
         if response.status_code == 201:
@@ -304,7 +317,11 @@ class BaseNeomarilClient(BaseNeomaril):
         response = requests.get(
             url,
             params={"force": str(force).lower()},
-            headers={"Authorization": "Bearer " + token},
+            headers={
+                "Authorization": "Bearer " + token,
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.refresh_group_token.__qualname__,
+            },
         )
 
         if response.status_code == 201:
@@ -550,7 +567,14 @@ class NeomarilExecution(BaseNeomaril):
             url = (
                 f"{self.base_url}/{self.__url_path}/result/{self.group}/{self.exec_id}"
             )
-            response = requests.get(url, headers={"Authorization": "Bearer " + token})
+            response = requests.get(
+                url,
+                headers={
+                    "Authorization": "Bearer " + token,
+                    "Neomaril-Origin": "Codex",
+                    "Neomaril-Method": self.download_result.__qualname__,
+                },
+            )
             if response.status_code not in [200, 410]:
                 formatted_msg = parse_json_to_yaml(response.json())
                 logger.error(f"Something went wrong...\n{formatted_msg}")

--- a/src/neomaril_codex/datasources.py
+++ b/src/neomaril_codex/datasources.py
@@ -115,7 +115,11 @@ class NeomarilDataSourceClient(BaseNeomarilClient):
             url=url,
             data=form_data,
             files=files,
-            headers={"Authorization": "Bearer " + token},
+            headers={
+                "Authorization": "Bearer " + token,
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.register_datasource.__qualname__,
+            },
             timeout=60,
         )
 
@@ -166,7 +170,13 @@ class NeomarilDataSourceClient(BaseNeomarilClient):
         token = refresh_token(*self.credentials, self.base_url)
 
         response = requests.get(
-            url=url, headers={"Authorization": "Bearer " + token}, timeout=60
+            url=url,
+            headers={
+                "Authorization": "Bearer " + token,
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.list_datasources.__qualname__,
+            },
+            timeout=60,
         )
         if response.status_code == 200:
             results = response.json().get("Results")
@@ -175,7 +185,9 @@ class NeomarilDataSourceClient(BaseNeomarilClient):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -304,7 +316,11 @@ class NeomarilDataSource(BaseNeomaril):
         response = requests.post(
             url=url,
             data=form_data,
-            headers={"Authorization": "Bearer " + token},
+            headers={
+                "Authorization": "Bearer " + token,
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.import_dataset.__qualname__,
+            },
             timeout=60,
         )
 
@@ -325,7 +341,9 @@ class NeomarilDataSource(BaseNeomaril):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -359,7 +377,13 @@ class NeomarilDataSource(BaseNeomaril):
         token = refresh_token(*self.credentials, self.base_url)
 
         response = requests.get(
-            url=url, headers={"Authorization": "Bearer " + token}, timeout=60
+            url=url,
+            headers={
+                "Authorization": "Bearer " + token,
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.list_datasets.__qualname__,
+            },
+            timeout=60,
         )
 
         return response.json().get("Results")
@@ -380,7 +404,13 @@ class NeomarilDataSource(BaseNeomaril):
 
         token = refresh_token(*self.credentials, self.base_url)
         response = requests.delete(
-            url=url, headers={"Authorization": "Bearer " + token}, timeout=60
+            url=url,
+            headers={
+                "Authorization": "Bearer " + token,
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.delete.__qualname__,
+            },
+            timeout=60,
         )
         logger.info(response.json().get("Message"))
 
@@ -501,7 +531,13 @@ class NeomarilDataset(BaseNeomaril):
         token = refresh_token(*self.credentials, self.base_url)
 
         response = requests.get(
-            url=url, headers={"Authorization": "Bearer " + token}, timeout=60
+            url=url,
+            headers={
+                "Authorization": "Bearer " + token,
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.get_status.__qualname__,
+            },
+            timeout=60,
         )
 
         if response.status_code == 200:
@@ -513,7 +549,9 @@ class NeomarilDataset(BaseNeomaril):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -536,7 +574,13 @@ class NeomarilDataset(BaseNeomaril):
 
         token = refresh_token(*self.credentials, self.base_url)
         response = requests.delete(
-            url=url, headers={"Authorization": "Bearer " + token}, timeout=60
+            url=url,
+            headers={
+                "Authorization": "Bearer " + token,
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.delete.__qualname__,
+            },
+            timeout=60,
         )
         if response.status_code == 200:
             logger.info(response.json().get("Message"))
@@ -545,7 +589,9 @@ class NeomarilDataset(BaseNeomaril):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:

--- a/src/neomaril_codex/model.py
+++ b/src/neomaril_codex/model.py
@@ -113,7 +113,9 @@ class NeomarilModel(BaseNeomaril):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code == 404:
@@ -175,7 +177,9 @@ class NeomarilModel(BaseNeomaril):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -227,7 +231,12 @@ class NeomarilModel(BaseNeomaril):
         elif self.operation == "sync":
             url = f"{self.base_url}/model/sync/health/{self.group}/{self.model_id}"
             response = requests.get(
-                url, headers={"Authorization": "Bearer " + self.__token}
+                url,
+                headers={
+                    "Authorization": "Bearer " + self.__token,
+                    "Neomaril-Origin": "Codex",
+                    "Neomaril-Method": self.health.__qualname__,
+                },
             )
             if response.status_code == 200:
                 return response.json()["Message"]
@@ -235,7 +244,9 @@ class NeomarilModel(BaseNeomaril):
             formatted_msg = parse_json_to_yaml(response.json())
 
             if response.status_code == 401:
-                logger.error("Login or password are invalid, please check your credentials.")
+                logger.error(
+                    "Login or password are invalid, please check your credentials."
+                )
                 raise AuthenticationError("Login not authorized.")
 
             if response.status_code >= 500:
@@ -268,14 +279,18 @@ class NeomarilModel(BaseNeomaril):
             url,
             headers={
                 "Authorization": "Bearer "
-                + refresh_token(*self.credentials, self.base_url)
+                + refresh_token(*self.credentials, self.base_url),
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.restart_model.__qualname__,
             },
         )
 
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -373,13 +388,19 @@ class NeomarilModel(BaseNeomaril):
         token = refresh_token(*self.credentials, self.base_url)
         req = requests.delete(
             f"{self.base_url}/model/delete/{self.group}/{self.model_id}",
-            headers={"Authorization": "Bearer " + token},
+            headers={
+                "Authorization": "Bearer " + token,
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.delete.__qualname__,
+            },
         )
 
         formatted_msg = parse_json_to_yaml(req.json())
 
         if req.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if req.status_code >= 500:
@@ -426,13 +447,19 @@ class NeomarilModel(BaseNeomaril):
         token = refresh_token(*self.credentials, self.base_url)
         req = requests.post(
             f"{self.base_url}/model/disable/{self.group}/{self.model_id}",
-            headers={"Authorization": "Bearer " + token},
+            headers={
+                "Authorization": "Bearer " + token,
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.disable.__qualname__,
+            },
         )
 
         formatted_msg = parse_json_to_yaml(req.json())
 
         if req.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if req.status_code >= 500:
@@ -528,7 +555,11 @@ class NeomarilModel(BaseNeomaril):
                     req = requests.post(
                         url,
                         data=json.dumps(model_input),
-                        headers={"Authorization": "Bearer " + group_token},
+                        headers={
+                            "Authorization": "Bearer " + group_token,
+                            "Neomaril-Origin": "Codex",
+                            "Neomaril-Method": self.predict.__qualname__,
+                        },
                     )
 
                     return req.json()
@@ -569,7 +600,11 @@ class NeomarilModel(BaseNeomaril):
                         url,
                         files=files,
                         data=form_data,
-                        headers={"Authorization": "Bearer " + group_token},
+                        headers={
+                            "Authorization": "Bearer " + group_token,
+                            "Neomaril-Origin": "Codex",
+                            "Neomaril-Method": self.predict.__qualname__,
+                        },
                     )
 
                     if req.status_code == 202:
@@ -609,7 +644,9 @@ class NeomarilModel(BaseNeomaril):
                 url,
                 headers={
                     "Authorization": "Bearer "
-                    + refresh_token(*self.credentials, self.base_url)
+                    + refresh_token(*self.credentials, self.base_url),
+                    "Neomaril-Origin": "Codex",
+                    "Neomaril-Method": self.predict.__qualname__,
                 },
             ).json()["Description"]
             if response["Status"] == "Deployed":
@@ -819,15 +856,17 @@ class NeomarilModel(BaseNeomaril):
                 res_message = message["Message"]
                 logger.error(f"Model monitoring host message: {res_message}")
                 raise ExecutionError("Monitoring host failed")
-        
+
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
-        
+
         if response.status_code >= 500:
             logger.error("Server is not available. Please, try it later.")
             raise ServerError("Server is not available!")
-        
+
         logger.error(response.text)
         raise ModelError("Could not get host monitoring status")
 
@@ -864,7 +903,9 @@ class NeomarilModel(BaseNeomaril):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -959,7 +1000,9 @@ class NeomarilModel(BaseNeomaril):
             files=upload_data,
             headers={
                 "Authorization": "Bearer "
-                + refresh_token(*self.credentials, self.base_url)
+                + refresh_token(*self.credentials, self.base_url),
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.register_monitoring.__qualname__,
             },
         )
 
@@ -976,7 +1019,9 @@ class NeomarilModel(BaseNeomaril):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -1284,7 +1329,9 @@ class NeomarilModelClient(BaseNeomarilClient):
             params=query,
             headers={
                 "Authorization": "Bearer "
-                + refresh_token(*self.credentials, self.base_url)
+                + refresh_token(*self.credentials, self.base_url),
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.search_models.__qualname__,
             },
         )
 
@@ -1310,7 +1357,9 @@ class NeomarilModelClient(BaseNeomarilClient):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -1481,7 +1530,9 @@ class NeomarilModelClient(BaseNeomarilClient):
             files=upload_data,
             headers={
                 "Authorization": "Bearer "
-                + refresh_token(*self.credentials, self.base_url)
+                + refresh_token(*self.credentials, self.base_url),
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.__upload_model.__qualname__,
             },
         )
 
@@ -1494,7 +1545,9 @@ class NeomarilModelClient(BaseNeomarilClient):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -1529,7 +1582,9 @@ class NeomarilModelClient(BaseNeomarilClient):
             url,
             headers={
                 "Authorization": "Bearer "
-                + refresh_token(*self.credentials, self.base_url)
+                + refresh_token(*self.credentials, self.base_url),
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.create_model.__qualname__,
             },
         )
         if response.status_code == 202:
@@ -1539,7 +1594,9 @@ class NeomarilModelClient(BaseNeomarilClient):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:

--- a/src/neomaril_codex/preprocessing.py
+++ b/src/neomaril_codex/preprocessing.py
@@ -229,7 +229,11 @@ class NeomarilPreprocessing(BaseNeomaril):
                     req = requests.post(
                         url,
                         data=json.dumps(preprocessing_input),
-                        headers={"Authorization": "Bearer " + group_token},
+                        headers={
+                            "Authorization": "Bearer " + group_token,
+                            "Neomaril-Origin": "Codex",
+                            "Neomaril-Method": self.run.__qualname__,
+                        },
                     )
 
                     return req.json()
@@ -242,7 +246,11 @@ class NeomarilPreprocessing(BaseNeomaril):
                     req = requests.post(
                         url,
                         files=files,
-                        headers={"Authorization": "Bearer " + group_token},
+                        headers={
+                            "Authorization": "Bearer " + group_token,
+                            "Neomaril-Origin": "Codex",
+                            "Neomaril-Method": self.run.__qualname__,
+                        },
                     )
 
                     # TODO: Shouldn't both sync and async preprocessing have the same succeeded status code?
@@ -277,7 +285,9 @@ class NeomarilPreprocessing(BaseNeomaril):
                         raise ServerError(req.text)
 
             else:
-                logger.error("Login or password are invalid, please check your credentials.")
+                logger.error(
+                    "Login or password are invalid, please check your credentials."
+                )
                 raise GroupError("Group token not informed.")
 
         return run
@@ -650,7 +660,9 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
             params=query,
             headers={
                 "Authorization": "Bearer "
-                + refresh_token(*self.credentials, self.base_url)
+                + refresh_token(*self.credentials, self.base_url),
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.search_preprocessing.__qualname__,
             },
         )
 
@@ -661,7 +673,9 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -843,7 +857,9 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -882,7 +898,9 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
             url,
             headers={
                 "Authorization": "Bearer "
-                + refresh_token(*self.credentials, self.base_url)
+                + refresh_token(*self.credentials, self.base_url),
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.create.__qualname__,
             },
         )
 
@@ -893,7 +911,9 @@ class NeomarilPreprocessingClient(BaseNeomarilClient):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:

--- a/src/neomaril_codex/training.py
+++ b/src/neomaril_codex/training.py
@@ -575,7 +575,9 @@ class NeomarilTrainingExecution(NeomarilExecution):
             url,
             headers={
                 "Authorization": "Bearer "
-                + refresh_token(*self.credentials, self.base_url)
+                + refresh_token(*self.credentials, self.base_url),
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.get_status.__qualname__,
             },
         )
         if response.status_code not in [200, 410]:
@@ -593,7 +595,9 @@ class NeomarilTrainingExecution(NeomarilExecution):
                 url,
                 headers={
                     "Authorization": "Bearer "
-                    + refresh_token(*self.credentials, self.base_url)
+                    + refresh_token(*self.credentials, self.base_url),
+                    "Neomaril-Origin": "Codex",
+                    "Neomaril-Method": self.get_status.__qualname__,
                 },
             )
             self.execution_data = response.json()["Description"]
@@ -626,7 +630,9 @@ class NeomarilTrainingExecution(NeomarilExecution):
             url,
             headers={
                 "Authorization": "Bearer "
-                + refresh_token(*self.credentials, self.base_url)
+                + refresh_token(*self.credentials, self.base_url),
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.promote_model.__qualname__,
             },
         )
         if response.status_code == 202:
@@ -635,7 +641,9 @@ class NeomarilTrainingExecution(NeomarilExecution):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -828,13 +836,15 @@ class NeomarilTrainingExperiment(BaseNeomaril):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
             logger.error("Server is not available. Please, try it later.")
             raise ServerError(f'Unable to retrive experiment "{training_id}"')
-        
+
         if response.status_code != 200:
             logger.error(f"Something went wrong...\n{formatted_msg}")
             raise Exception("Unexpected error.")
@@ -1042,7 +1052,9 @@ class NeomarilTrainingExperiment(BaseNeomaril):
             return re.search(patt, raw_response).group(1)
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -1072,7 +1084,9 @@ class NeomarilTrainingExperiment(BaseNeomaril):
             url,
             headers={
                 "Authorization": "Bearer "
-                + refresh_token(*self.credentials, self.base_url)
+                + refresh_token(*self.credentials, self.base_url),
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.run_training.__qualname__,
             },
         )
         if response.status_code == 200:
@@ -1082,7 +1096,9 @@ class NeomarilTrainingExperiment(BaseNeomaril):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -1108,17 +1124,18 @@ class NeomarilTrainingExperiment(BaseNeomaril):
         formatted_msg = parse_json_to_yaml(response.json())
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
             logger.error("Server is not available. Please, try it later.")
             raise ServerError(f'Unable to retrive experiment "{self.training_id}"')
-        
+
         if response.status_code != 200:
             logger.error(f"Something went wrong...\n{formatted_msg}")
             raise Exception("Unexpected error.")
-
 
         self.training_data = response.json()["Description"]
         self.executions = [c["Id"] for c in self.training_data["Executions"]]
@@ -1519,7 +1536,9 @@ class NeomarilTrainingClient(BaseNeomarilClient):
             raise InputError("Bad Input")
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:
@@ -1575,7 +1594,9 @@ class NeomarilTrainingClient(BaseNeomarilClient):
             data=data,
             headers={
                 "Authorization": "Bearer "
-                + refresh_token(*self.credentials, self.base_url)
+                + refresh_token(*self.credentials, self.base_url),
+                "Neomaril-Origin": "Codex",
+                "Neomaril-Method": self.__create.__qualname__,
             },
         )
 
@@ -1586,7 +1607,9 @@ class NeomarilTrainingClient(BaseNeomarilClient):
             raise InputError("Bad Input")
 
         if response.status_code == 401:
-            logger.error("Login or password are invalid, please check your credentials.")
+            logger.error(
+                "Login or password are invalid, please check your credentials."
+            )
             raise AuthenticationError("Login not authorized.")
 
         if response.status_code >= 500:


### PR DESCRIPTION
## Description

With this pr:
* Add a custom header for the codex requests `{"Neomaril-Origin": "Codex", "Neomaril-Method": <method>}`

## Related issues

* Closes: https://linear.app/datarisk/issue/NEODV-1357/[task]-adicionar-um-header-de-origem-nas-requisicoes-do-codex

## How to test it

